### PR TITLE
0.0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ or manually using this URL:
 
 ## Changelog
 
+**[0.0.5]** (04/18/2018)
+
+**Changed**
+  - Graph is now always visible in OctoPrint as long as you have saving enabled, there is a mesh stored, and the user is logged in.
+
+**Fixed**
+  - Remove duplicated tabs from Prusa firmware's M81 response.
+
 **[0.0.4]** (04/17/2018)
 
 **Changed**
@@ -63,6 +71,7 @@ or manually using this URL:
 
 **Initial Release**
 
+[0.0.5]: https://github.com/jneilliii/OctoPrint-BedLevelVisualizer/tree/0.0.5
 [0.0.4]: https://github.com/jneilliii/OctoPrint-BedLevelVisualizer/tree/0.0.4
 [0.0.3]: https://github.com/jneilliii/OctoPrint-BedLevelVisualizer/tree/0.0.3
 [0.0.2]: https://github.com/jneilliii/OctoPrint-BedLevelVisualizer/tree/0.0.2

--- a/README.md
+++ b/README.md
@@ -40,11 +40,14 @@ or manually using this URL:
 
 **[0.0.5]** (04/18/2018)
 
+**Added**
+  - Prusa Firmware Mode setting, to handle G81 responses correctly
+
 **Changed**
   - Graph is now always visible in OctoPrint as long as you have saving enabled, there is a mesh stored, and the user is logged in.
 
 **Fixed**
-  - Remove duplicated tabs from Prusa firmware's M81 response.
+  - Remove duplicated tabs from Prusa firmware's G81 response.
 
 **[0.0.4]** (04/17/2018)
 

--- a/octoprint_bedlevelvisualizer/__init__.py
+++ b/octoprint_bedlevelvisualizer/__init__.py
@@ -37,7 +37,8 @@ class bedlevelvisualizer(octoprint.plugin.StartupPlugin,
 		if self.processing and "ok" not in line and re.match(r"\s?\d?\s?(\+?-?\[?\s?\d+.\d+[\]?,?\s?]+)+", line.strip()):
 			new_line = re.sub(r"< \d+:\d+:\d+(\s+(AM|PM))?:","",line.strip())
 			new_line = re.sub(r"[\[\]]\s?","",new_line)
-			new_line = re.sub(r"\s+","\t",new_line)	
+			new_line = re.sub(r"\s+","\t",new_line)
+			new_line = re.sub(r"(\t)\1{1,}","\t",new_line)
 			new_line = new_line.split("\t")
 			if self._settings.get(["report_flag"]) in ["Bilinear Leveling Grid:","Subdivided with CATMULL ROM Leveling Grid:","Measured points:"]:
 				new_line.pop(0)

--- a/octoprint_bedlevelvisualizer/__init__.py
+++ b/octoprint_bedlevelvisualizer/__init__.py
@@ -41,7 +41,9 @@ class bedlevelvisualizer(octoprint.plugin.StartupPlugin,
 			new_line = re.sub(r"\s+"," ",new_line)
 			new_line = re.sub(r"\s+","\t",new_line)
 			new_line = new_line.split("\t")			
-			self._logger.info("converted to:" + new_line);
+			self._logger.info("converted to:")
+			self._logger.info(new_line)
+			
 			if self._settings.get(["report_flag"]) in ["Bilinear Leveling Grid:","Subdivided with CATMULL ROM Leveling Grid:","Measured points:"] and not self._settings.get(["prusa_mode"]):
 				new_line.pop(0)
 			if len(new_line) > 0:

--- a/octoprint_bedlevelvisualizer/__init__.py
+++ b/octoprint_bedlevelvisualizer/__init__.py
@@ -15,7 +15,7 @@ class bedlevelvisualizer(octoprint.plugin.StartupPlugin,
 	
 	##~~ SettingsPlugin
 	def get_settings_defaults(self):
-		return dict(command="G28\nG29 T1",stored_mesh=[],save_mesh=True,report_flag="Bilinear Leveling Grid:",report_types=["Bed Topography Report:","Bilinear Leveling Grid:","Subdivided with CATMULL ROM Leveling Grid:","Measured points:"])
+		return dict(command="G28\nG29 T1",stored_mesh=[],save_mesh=True,prusa_mode=False,report_flag="Bilinear Leveling Grid:",report_types=["Bed Topography Report:","Bilinear Leveling Grid:","Subdivided with CATMULL ROM Leveling Grid:","Measured points:"])
 
 	##~~ StartupPlugin
 	def on_after_startup(self):
@@ -35,12 +35,14 @@ class bedlevelvisualizer(octoprint.plugin.StartupPlugin,
 			return line
 			
 		if self.processing and "ok" not in line and re.match(r"\s?\d?\s?(\+?-?\[?\s?\d+.\d+[\]?,?\s?]+)+", line.strip()):
+			self._logger.info(line.strip());
 			new_line = re.sub(r"< \d+:\d+:\d+(\s+(AM|PM))?:","",line.strip())
 			new_line = re.sub(r"[\[\]]\s?","",new_line)
+			new_line = re.sub(r"\s+"," ",new_line)
 			new_line = re.sub(r"\s+","\t",new_line)
-			new_line = re.sub(r"(\t)\1{1,}","\t",new_line)
-			new_line = new_line.split("\t")
-			if self._settings.get(["report_flag"]) in ["Bilinear Leveling Grid:","Subdivided with CATMULL ROM Leveling Grid:","Measured points:"]:
+			new_line = new_line.split("\t")			
+			self._logger.info("converted to:" + new_line);
+			if self._settings.get(["report_flag"]) in ["Bilinear Leveling Grid:","Subdivided with CATMULL ROM Leveling Grid:","Measured points:"] and not self._settings.get(["prusa_mode"]):
 				new_line.pop(0)
 			if len(new_line) > 0:
 				self.mesh.append(new_line)

--- a/octoprint_bedlevelvisualizer/static/js/bedlevelvisualizer.js
+++ b/octoprint_bedlevelvisualizer/static/js/bedlevelvisualizer.js
@@ -76,12 +76,10 @@ $(function () {
 
 		self.onAfterTabChange = function (current, previous) {
 			if (current === "#tab_plugin_bedlevelvisualizer" && self.controlViewModel.isOperational() && !self.controlViewModel.isPrinting() && self.loginStateViewModel.isUser() && !self.processing()) {
-				if (!self.save_mesh()) {
+				if (!self.save_mesh() && self.controlViewModel.isOperational() && !self.controlViewModel.isPrinting()) {
 					self.updateMesh();
 				} else {
 					if(!self.settingsViewModel.settings.plugins.bedlevelvisualizer.stored_mesh().length > 0){
-						self.updateMesh();
-					} else {
 						self.drawMesh(self.mesh_data());
 					}
 				}

--- a/octoprint_bedlevelvisualizer/static/js/bedlevelvisualizer.js
+++ b/octoprint_bedlevelvisualizer/static/js/bedlevelvisualizer.js
@@ -75,13 +75,11 @@ $(function () {
 		};
 
 		self.onAfterTabChange = function (current, previous) {
-			if (current === "#tab_plugin_bedlevelvisualizer" && self.controlViewModel.isOperational() && !self.controlViewModel.isPrinting() && self.loginStateViewModel.isUser() && !self.processing()) {
+			if (current === "#tab_plugin_bedlevelvisualizer" && self.loginStateViewModel.isUser() && !self.processing()) {
 				if (!self.save_mesh() && self.controlViewModel.isOperational() && !self.controlViewModel.isPrinting()) {
 					self.updateMesh();
 				} else {
-					if(!self.settingsViewModel.settings.plugins.bedlevelvisualizer.stored_mesh().length > 0){
-						self.drawMesh(self.mesh_data());
-					}
+					self.drawMesh(self.mesh_data());
 				}
 				return;
 			}

--- a/octoprint_bedlevelvisualizer/templates/bedlevelvisualizer_settings.jinja2
+++ b/octoprint_bedlevelvisualizer/templates/bedlevelvisualizer_settings.jinja2
@@ -9,7 +9,7 @@
 	<textarea class="input-block-level" id="bedlevelvisualizer_command" rows="4" data-bind="value: settingsViewModel.settings.plugins.bedlevelvisualizer.command"></textarea>
 </div>
 <div class="control-group">
-	<i class="icon icon-info-sign" title="Save/Load mesh data to/from config.yaml"></i> Save Mesh<input class="input-checkbox" type="checkbox" id="bedlevelvisualizer_save_mesh" data-bind="checked: settingsViewModel.settings.plugins.bedlevelvisualizer.save_mesh" style="display: inline-block;margin-bottom: 5px;"></input>
+	<i class="icon icon-info-sign" title="Save/Load mesh data to/from config.yaml"></i> Save Mesh <input class="input-checkbox" type="checkbox" id="bedlevelvisualizer_save_mesh" data-bind="checked: settingsViewModel.settings.plugins.bedlevelvisualizer.save_mesh" style="display: inline-block;margin-bottom: 5px;"></input>
 </div>
 <div class="control-group">
 	<label for="bedlevelvisualizer_command">Stored Mesh Data:</label>

--- a/octoprint_bedlevelvisualizer/templates/bedlevelvisualizer_settings.jinja2
+++ b/octoprint_bedlevelvisualizer/templates/bedlevelvisualizer_settings.jinja2
@@ -12,6 +12,9 @@
 	<i class="icon icon-info-sign" title="Save/Load mesh data to/from config.yaml"></i> Save Mesh <input class="input-checkbox" type="checkbox" id="bedlevelvisualizer_save_mesh" data-bind="checked: settingsViewModel.settings.plugins.bedlevelvisualizer.save_mesh" style="display: inline-block;margin-bottom: 5px;"></input>
 </div>
 <div class="control-group">
+	<i class="icon icon-info-sign" title="Enable to support Prusa Firmware"></i> Prusa Firmware Mode <input class="input-checkbox" type="checkbox" id="bedlevelvisualizer_prusa_mode" data-bind="checked: settingsViewModel.settings.plugins.bedlevelvisualizer.prusa_mode" style="display: inline-block;margin-bottom: 5px;"></input>
+</div>
+<div class="control-group">
 	<label for="bedlevelvisualizer_command">Stored Mesh Data:</label>
 	<pre id="bedlevelvisualizer_data" data-bind="text: settingsViewModel.settings.plugins.bedlevelvisualizer.stored_mesh().join('\n').replace(/,/g,'\t')"></pre>
 </div>

--- a/octoprint_bedlevelvisualizer/templates/bedlevelvisualizer_tab.jinja2
+++ b/octoprint_bedlevelvisualizer/templates/bedlevelvisualizer_tab.jinja2
@@ -4,9 +4,9 @@
 	transform: translateX(-50%);
 }
 </style>
-<div class="row-fluid" id="bedlevelvisualizerwait" style="text-align: center;font-size: 25px;vertical-align: middle;" data-bind="visible: controlViewModel.isOperational() && !controlViewModel.isPrinting() && loginStateViewModel.isUser() && processing()"><i class="icon-spinner icon-spin icon-3"></i> <b>Please wait, retrieving current mesh.</b></div>
-<div class="row-fluid" id="bedlevelvisualizerwarning" style="text-align: center;font-size: 25px;vertical-align: middle;" data-bind="visible: ((!controlViewModel.isOperational() || controlViewModel.isPrinting()) && loginStateViewModel.isUser())"><i class="icon-warning-sign icon-3" style="color:red"></i> <b>You must be connected and not printing!</b></div>
-<div class="row-fluid" data-bind="visible: controlViewModel.isOperational() && !controlViewModel.isPrinting() && loginStateViewModel.isUser() && !processing()">
+<div class="row-fluid" id="bedlevelvisualizerwait" style="text-align: center;font-size: 25px;vertical-align: middle;" data-bind="visible: processing()"><i class="icon-spinner icon-spin icon-3"></i> <b>Please wait, retrieving current mesh.</b></div>
+<div class="row-fluid" id="bedlevelvisualizerwarning" style="text-align: center;font-size: 25px;vertical-align: middle;" data-bind="visible: (((!controlViewModel.isOperational() || controlViewModel.isPrinting()) && (!settingsViewModel.settings.plugins.bedlevelvisualizer.save_mesh() && !settingsViewModel.settings.plugins.bedlevelvisualizer.stored_mesh().length > 0) && loginStateViewModel.isUser()))"><i class="icon-warning-sign icon-3" style="color:red"></i> <b>You must be connected and not printing!</b></div>
+<div class="row-fluid" data-bind="visible: (((controlViewModel.isOperational() || !controlViewModel.isPrinting()) && (settingsViewModel.settings.plugins.bedlevelvisualizer.save_mesh() && settingsViewModel.settings.plugins.bedlevelvisualizer.stored_mesh().length > 0) && loginStateViewModel.isUser()))">
 	<div class="row-fluid" id="bedlevelvisualizergraph"></div>
 	<div class="row-fluid" id="bedlevelvisualizerbutton" style="text-align: center;padding-top: 20px;"><button class="btn" data-bind="click: updateMesh,enable: controlViewModel.isOperational() && !controlViewModel.isPrinting() && loginStateViewModel.isUser() && !processing()"><i class="icon-2 icon-info-sign" data-bind="attr: {'title': mesh_status}"></i> Update</button></div>
 </div>

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_bedlevelvisualizer"
 plugin_name = "Bed Visualizer"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.0.4"
+plugin_version = "0.0.5"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
**Added**
  - Prusa Firmware Mode setting, to handle G81 responses correctly

**Changed**
  - Graph is now always visible in OctoPrint as long as you have saving enabled, there is a mesh stored, and the user is logged in.

**Fixed**
  - Remove duplicated tabs from Prusa firmware's G81 response.