### PR TITLE
Add support for Marlin 2.0.0 Bilinear and CATMULL ROM

### DIFF
--- a/octoprint_bedlevelvisualizer/templates/bedlevelvisualizer_settings.jinja2
+++ b/octoprint_bedlevelvisualizer/templates/bedlevelvisualizer_settings.jinja2
@@ -35,6 +35,14 @@
 					</div>
 				</div>
 				<div class="row-fluid">
+					<div class="control-group span4">
+						<i class="icon icon-info-sign" title="Bilinear Leveling Support" data-toggle="tooltip"></i> Bilinear Mesh Leveling <input class="input-checkbox" type="checkbox" id="bedlevelvisualizer_bilinear" data-bind="checked: settingsViewModel.settings.plugins.bedlevelvisualizer.leveling_bilinear" style="display: inline-block;margin-bottom: 5px;"></input>
+					</div>
+                                        <div class="control-group span4">
+                                                <i class="icon icon-info-sign" title="CATMULL ROM Leveling Support" data-toggle="tooltip"></i> CATMULL ROM Mesh Expansion <input class="input-checkbox" type="checkbox" id="bedlevelvisualizer_catmull" data-bind="checked: settingsViewModel.settings.plugins.bedlevelvisualizer.leveling_catmull" style="display: inline-block;margin-bottom: 5px;"></input>
+					</div>				
+				</div>
+				<div class="row-fluid">
 					<div class="control-group">
 						<label for="bedlevelvisualizer_timeout"><i class="icon icon-info-sign" title="Timeout value that will stop processing of visualizer in milliseconds." data-toggle="tooltip"></i> Timeout</label>
 						<div class="input-append">


### PR DESCRIPTION
Added support for Marlin bugfix-2.0.0 branch bilinear and catmull rom expansion options. Dont have ability to test that i did not break anything else but it should not.

Parses example output and allows selection between basic grid or expanded grid.


Bilinear Leveling Grid:
      0      1      2      3
 0 -0.237 -0.105 -0.053 -0.111
 1 -0.148 -0.029 -0.016 +0.014
 2 -0.083 -0.097 -0.095 -0.061
 3 +0.135 +0.107 -0.061 -0.161

Subdivided with CATMULL ROM Leveling Grid:
        0        1        2        3        4        5        6        7        8        9
 0 -0.23650 -0.18974 -0.14298 -0.10500 -0.07756 -0.05889 -0.05250 -0.06365 -0.08707 -0.11050
 1 -0.20615 -0.15875 -0.11136 -0.07433 -0.05221 -0.04046 -0.03585 -0.03968 -0.05066 -0.06163
 2 -0.17580 -0.12777 -0.07973 -0.04367 -0.02687 -0.02204 -0.01920 -0.01572 -0.01424 -0.01276
 3 -0.14800 -0.10443 -0.06085 -0.02900 -0.01728 -0.01728 -0.01550 -0.00685 +0.00357 +0.01400
 4 -0.13007 -0.10131 -0.07255 -0.05107 -0.04280 -0.04181 -0.03759 -0.02559 -0.01037 +0.00485
 5 -0.11470 -0.10585 -0.09700 -0.08915 -0.08407 -0.08000 -0.07263 -0.05942 -0.04292 -0.02641
 6 -0.08250 -0.08795 -0.09339 -0.09700 -0.09876 -0.09869 -0.09500 -0.08591 -0.07320 -0.06050
 7 -0.02139 -0.03009 -0.03878 -0.04915 -0.06389 -0.08029 -0.09195 -0.09512 -0.09353 -0.09195
 8 +0.05656 +0.05022 +0.04388 +0.02893 -0.00242 -0.04239 -0.07622 -0.09697 -0.11160 -0.12622
 9 +0.13450 +0.13052 +0.12654 +0.10700 +0.05904 -0.00448 -0.06050 -0.09883 -0.12967 -0.16050