### PR TITLE
Fix minor bug where lines w/ "1 |[+0.019] -0.137" are not matched

### DIFF
--- a/octoprint_bedlevelvisualizer/__init__.py
+++ b/octoprint_bedlevelvisualizer/__init__.py
@@ -68,7 +68,7 @@ class bedlevelvisualizer(octoprint.plugin.StartupPlugin,
 		return
 	
 	def processGCODE(self, comm, line, *args, **kwargs):
-		if self.processing and "ok" not in line and re.match(r"^((G33.+)|(Bed.+)|(\d+\s)|(\|\s+)|(\[?\s?\+?\-?\d?\.\d+\]?\s*\,?)|(\s?\.\s*)|(NAN\,?))+$", line.strip()):			
+		if self.processing and "ok" not in line and re.match(r"^((G33.+)|(Bed.+)|(\d+\s)|(\|\s*)|(\[?\s?\+?\-?\d?\.\d+\]?\s*\,?)|(\s?\.\s*)|(NAN\,?))+$", line.strip()):
 			new_line = re.findall(r"(\+?\-?\d*\.\d*)",line)
 			
 			if re.match(r"^Bed x:.+$", line.strip()):


### PR DESCRIPTION
Some topology reports have the first value after "|" in brackets like this:
```
Recv: Bed Topography Report:
Recv: 
Recv:     ( 10,294)                                      (294,294)
Recv:         0       1       2       3       4       5       6
Recv:  6 | +0.290  +0.088  -0.058  -0.144  -0.181  -0.169  -0.064
Recv:    |
Recv:  5 | +0.174  -0.021  -0.152  -0.223  -0.247  -0.230  -0.097
Recv:    |
Recv:  4 | +0.147  -0.016  -0.146  -0.206  -0.246  -0.203  -0.051
Recv:    |
Recv:  3 | +0.113  -0.067  -0.172  -0.212  -0.253  -0.179  -0.022
Recv:    |
Recv:  2 | +0.075  -0.104  -0.206  -0.242  -0.273  -0.173  -0.005
Recv:    |
Recv:  1 |[+0.019] -0.137  -0.239  -0.291  -0.299  -0.192  +0.018
Recv:    |
Recv:  0 |   .       .       .       .       .       .       .
Recv:         0       1       2       3       4       5       6
Recv:     ( 10, 10)                                      (294, 10)
Recv: 
Recv: ok
```
The PR changes the regexp to optional whitespaces following the '|'