### PR TITLE
Support MBL, OpenSCAD output, Invalid Mesh error

### DIFF
--- a/octoprint_bedlevelvisualizer/__init__.py
+++ b/octoprint_bedlevelvisualizer/__init__.py
@@ -73,9 +73,9 @@ class bedlevelvisualizer(octoprint.plugin.StartupPlugin,
 		return
 
 	def processGCODE(self, comm, line, *args, **kwargs):
-		if self._settings.get_boolean(["ignore_correction_matrix"]) and re.match(r"^Bed Level Correction Matrix:.*$", line.strip()):
+		if self._settings.get_boolean(["ignore_correction_matrix"]) and re.match(r"^(Mesh )?Bed Level (Correction Matrix|data):.*$", line.strip()):
 			line = "ok"
-		if self.processing and "ok" not in line and re.match(r"^((G33.+)|(Bed.+)|(\d+\s)|(\|\s*)|(\[?\s?\+?\-?\d?\.\d+\]?\s*\,?)|(\s?\.\s*)|(NAN\,?))+$", line.strip()):
+		if self.processing and "ok" not in line and re.match(r"^((G33.+)|(Bed.+)|(\d+\s)|(\|\s*)|(\s*\[\s+)|(\[?\s?\+?\-?\d?\.\d+\]?\s*\,?)|(\s?\.\s*)|(NAN\,?))+(\s+\],?)?$", line.strip()):
 			new_line = re.findall(r"(\+?\-?\d*\.\d*)",line)
 
 			if re.match(r"^Bed x:.+$", line.strip()):
@@ -111,7 +111,7 @@ class bedlevelvisualizer(octoprint.plugin.StartupPlugin,
 		if self.processing and self.old_marlin and re.match(r"^Eqn coefficients:.+$", line.strip()):
 			self.old_marlin_offset = re.sub("^(Eqn coefficients:.+)(\d+.\d+)$",r"\2", line.strip())
 
-		if self.processing and "Home XYZ first" in line:
+		if self.processing and "Home XYZ first" in line or "Invalid mesh" in line:
 			self._plugin_manager.send_plugin_message(self._identifier, dict(error=line.strip()))
 			self.processing = False
 			return line

--- a/octoprint_bedlevelvisualizer/static/js/bedlevelvisualizer.js
+++ b/octoprint_bedlevelvisualizer/static/js/bedlevelvisualizer.js
@@ -12,8 +12,8 @@ $(function () {
 		self.mesh_data_y = ko.observableArray([]);
 		self.mesh_data_z_height = ko.observable();
 		self.save_mesh = ko.observable();
-		self.mesh_status = ko.computed(function(){
-			if(self.processing()){
+		self.mesh_status = ko.computed(function() {
+			if (self.processing()) {
 				return 'Collecting mesh data.';
 			}
 			if (self.save_mesh() && self.mesh_data().length > 0) {
@@ -22,7 +22,7 @@ $(function () {
 				return 'Update mesh.'
 			}
 		});
-		
+
 		self.onBeforeBinding = function() {
 			self.mesh_data(self.settingsViewModel.settings.plugins.bedlevelvisualizer.stored_mesh());
 			self.mesh_data_x(self.settingsViewModel.settings.plugins.bedlevelvisualizer.stored_mesh_x());
@@ -30,11 +30,11 @@ $(function () {
 			self.mesh_data_z_height(self.settingsViewModel.settings.plugins.bedlevelvisualizer.stored_mesh_z_height());
 			self.save_mesh(self.settingsViewModel.settings.plugins.bedlevelvisualizer.save_mesh());
 		}
-		
+
 		self.onAfterBinding = function() {
 			$('div#settings_plugin_bedlevelvisualizer i[data-toggle="tooltip"],div#tab_plugin_bedlevelvisualizer i[data-toggle="tooltip"],div#wizard_plugin_bedlevelvisualizer i[data-toggle="tooltip"],div#settings_plugin_bedlevelvisualizer pre[data-toggle="tooltip"]').tooltip();
 		}
-		
+
 		self.onEventSettingsUpdated = function (payload) {
 			self.mesh_data(self.settingsViewModel.settings.plugins.bedlevelvisualizer.stored_mesh());
 			self.save_mesh(self.settingsViewModel.settings.plugins.bedlevelvisualizer.save_mesh());
@@ -48,33 +48,33 @@ $(function () {
 				if (mesh_data.mesh.length > 0) {
 					var x_data = [];
 					var y_data = [];
-					
-					for(var i = 0;i <= (mesh_data.mesh[0].length - 1);i++){
-						if((mesh_data.bed.type == "circular") || self.settingsViewModel.settings.plugins.bedlevelvisualizer.use_center_origin()){
+
+					for(var i = 0;i <= (mesh_data.mesh[0].length - 1);i++) {
+						if ((mesh_data.bed.type == "circular") || self.settingsViewModel.settings.plugins.bedlevelvisualizer.use_center_origin()) {
 							x_data.push(Math.round(mesh_data.bed.x_min - (mesh_data.bed.x_max/2)+i/(mesh_data.mesh[0].length - 1)*(mesh_data.bed.x_max - mesh_data.bed.x_min)));
 						} else {
 							x_data.push(Math.round(mesh_data.bed.x_min+i/(mesh_data.mesh[0].length - 1)*(mesh_data.bed.x_max - mesh_data.bed.x_min)));
 						}
 					};
-					
-					for(var i = 0;i <= (mesh_data.mesh.length - 1);i++){
-						if((mesh_data.bed.type == "circular") || self.settingsViewModel.settings.plugins.bedlevelvisualizer.use_center_origin()){
+
+					for(var i = 0;i <= (mesh_data.mesh.length - 1);i++) {
+						if ((mesh_data.bed.type == "circular") || self.settingsViewModel.settings.plugins.bedlevelvisualizer.use_center_origin()) {
 							y_data.push(Math.round(mesh_data.bed.y_min - (mesh_data.bed.y_max/2)+i/(mesh_data.mesh.length - 1)*(mesh_data.bed.y_max - mesh_data.bed.y_min)));
 						} else {
 							y_data.push(Math.round(mesh_data.bed.y_min+i/(mesh_data.mesh.length - 1)*(mesh_data.bed.y_max - mesh_data.bed.y_min)));
 						}
 					};
-					
+
 					self.drawMesh(mesh_data.mesh,true,x_data,y_data,mesh_data.bed.z_max);
 				}
 				return;
 			}
 			if (mesh_data.error) {
 				new PNotify({
-						title: 'Bed Visualizer Error',
-						text: '<div class="row-fluid"><p>Looks like your settings are not correct or there was an error.</p><p>Please see the <a href="https://github.com/jneilliii/OctoPrint-BedLevelVisualizer/#tips" target="_blank">Readme</a> for configuration tips.</p></div><p><pre style="padding-top: 5px;">'+mesh_data.error+'</pre></p>',
-						hide: true
-						});	
+					title: 'Bed Visualizer Error',
+					text: '<div class="row-fluid"><p>Looks like your settings are not correct or there was an error.</p><p>Please see the <a href="https://github.com/jneilliii/OctoPrint-BedLevelVisualizer/#tips" target="_blank">Readme</a> for configuration tips.</p></div><p><pre style="padding-top: 5px;">'+mesh_data.error+'</pre></p>',
+					hide: true
+				});
 				return;
 			}
 			return;
@@ -84,8 +84,8 @@ $(function () {
 			// console.log(mesh_data_z+'\n'+store_data+'\n'+mesh_data_x+'\n'+mesh_data_y+'\n'+mesh_data_z_height);
 			clearTimeout(self.timeout);
 			self.processing(false);
-			if(self.save_mesh()){
-				if(store_data){
+			if (self.save_mesh()) {
+				if (store_data) {
 					self.settingsViewModel.settings.plugins.bedlevelvisualizer.stored_mesh(mesh_data_z);
 					self.settingsViewModel.settings.plugins.bedlevelvisualizer.stored_mesh_x(mesh_data_x);
 					self.settingsViewModel.settings.plugins.bedlevelvisualizer.stored_mesh_y(mesh_data_y);
@@ -94,7 +94,7 @@ $(function () {
 					self.settingsViewModel.saveData();
 				};
 			}
-			
+
 			try {
 				var data = [{
 						z: mesh_data_z,
@@ -126,7 +126,7 @@ $(function () {
 						}
 					}
 				};
-				
+
 				var config_options = {
 					modeBarButtonsToRemove: ['resetCameraLastSave3d'],
 					modeBarButtonsToAdd: [{
@@ -136,8 +136,8 @@ $(function () {
 					click: function(gd, ev) {
 						var button = ev.currentTarget;
 						var button_enabled = button._previousVal || false;
-						if(!button_enabled){
-							gd.on('plotly_click', function(data){
+						if (!button_enabled) {
+							gd.on('plotly_click', function(data) {
 									var gcode_command = 'G1 X' + data.points[0].x + ' Y' + data.points[0].y
 									OctoPrint.control.sendGcode([gcode_command]);
 								});
@@ -149,7 +149,7 @@ $(function () {
 					}
 					}]
 				}
-				
+
 				Plotly.react('bedlevelvisualizergraph', data, layout, config_options);
 			} catch(err) {
 				new PNotify({
@@ -169,10 +169,10 @@ $(function () {
 					}
 				} else if (self.settingsViewModel.settings.plugins.bedlevelvisualizer.stored_mesh().length > 0) {
 					self.drawMesh(self.mesh_data(),false,self.settingsViewModel.settings.plugins.bedlevelvisualizer.stored_mesh_x(),self.settingsViewModel.settings.plugins.bedlevelvisualizer.stored_mesh_y(),self.settingsViewModel.settings.plugins.bedlevelvisualizer.stored_mesh_z_height());
-				} 
+				}
 				return;
 			}
-			
+
 			if (previous === "#tab_plugin_bedlevelvisualizer") {
 				//Plotly.purge('bedlevelvisualizergraph');
 			}
@@ -182,17 +182,17 @@ $(function () {
 			self.processing(true);
 			self.timeout = setTimeout(function(){self.processing(false);new PNotify({title: 'Bed Visualizer Error',text: '<div class="row-fluid">Timeout occured before prcessing completed. Processing may still be running or there may be a configuration error. Consider increasing the timeout value in settings.</div>',type: 'info',hide: true});}, (parseInt(self.settingsViewModel.settings.plugins.bedlevelvisualizer.timeout())*1000));
 			var gcode_cmds = self.settingsViewModel.settings.plugins.bedlevelvisualizer.command().split("\n");
-			if (gcode_cmds.indexOf("@BEDLEVELVISUALIZER") == -1){
+			if (gcode_cmds.indexOf("@BEDLEVELVISUALIZER") == -1) {
 				gcode_cmds = ["@BEDLEVELVISUALIZER"].concat(gcode_cmds);
 			}
 			// clean extraneous code
 			gcode_cmds = gcode_cmds.filter(function(array_val) {
-					var x = Boolean(array_val);
-					return x == true;
-				});
-				
+				var x = Boolean(array_val);
+				return x == true;
+			});
+
 			console.log(gcode_cmds);
-				
+
 			OctoPrint.control.sendGcode(gcode_cmds);
 		};
 	}

--- a/virtual_level_report_cartesian_Mesh_Bed_Level_data.gcode
+++ b/virtual_level_report_cartesian_Mesh_Bed_Level_data.gcode
@@ -1,0 +1,12 @@
+@BEDLEVELVISUALIZER
+!!DEBUG:send Mesh Bed Level data:
+!!DEBUG:send 6 x 6 mesh. Z offset: 0.00000
+!!DEBUG:send Measured points:
+!!DEBUG:send       0      1      2      3      4      5
+!!DEBUG:send 0 +0.200 +0.093 +0.039 -0.005 -0.048 -0.072
+!!DEBUG:send 1 +0.176 +0.063 -0.018 -0.039 -0.048 -0.040
+!!DEBUG:send 2 +0.178 +0.059 -0.024 -0.040 -0.054 -0.047
+!!DEBUG:send 3 +0.206 +0.078 -0.008 -0.036 -0.064 -0.082
+!!DEBUG:send 4 +0.243 +0.098 -0.008 -0.064 -0.127 -0.164
+!!DEBUG:send 5 +0.249 +0.124 +0.001 -0.072 -0.159 -0.247
+!!DEBUG:send ok

--- a/virtual_level_report_cartesian_Mesh_Bed_Level_scad.gcode
+++ b/virtual_level_report_cartesian_Mesh_Bed_Level_scad.gcode
@@ -1,0 +1,13 @@
+@BEDLEVELVISUALIZER
+!!DEBUG:send Mesh Bed Level data:
+!!DEBUG:send 6 x 6 mesh. Z offset: 0.00000
+!!DEBUG:send Measured points:
+!!DEBUG:send measured_z = [
+!!DEBUG:send  [ +0.200, +0.093, +0.039, -0.005, -0.048, -0.072 ],
+!!DEBUG:send  [ +0.176, +0.063, -0.018, -0.039, -0.048, -0.040 ],
+!!DEBUG:send  [ +0.178, +0.059, -0.024, -0.040, -0.054, -0.047 ],
+!!DEBUG:send  [ +0.206, +0.078, -0.008, -0.036, -0.064, -0.082 ],
+!!DEBUG:send  [ +0.243, +0.098, -0.008, -0.064, -0.127, -0.164 ],
+!!DEBUG:send  [ +0.249, +0.124, +0.001, -0.072, -0.159, -0.247 ]
+!!DEBUG:send ];
+!!DEBUG:send ok


### PR DESCRIPTION
- Mesh Bed Leveling is a guided procedure for bed leveling which can be done from host or from LCD. It produces a mesh just like ABL Bilinear. A compare is added for the MBL mesh header.
- A hidden option for developers allows mesh output to be formatted for OpenSCAD. Sometimes we forget to turn it off. The regex is updated to support this format.
- Sample meshes are added to illustrate and test these new cases.
