### PR TITLE
Fix x axis flip issue.

### DIFF
--- a/octoprint_bedlevelvisualizer/__init__.py
+++ b/octoprint_bedlevelvisualizer/__init__.py
@@ -206,7 +206,7 @@ class bedlevelvisualizer(octoprint.plugin.StartupPlugin,
 					new_line.pop(0)
 				if len(new_line) > 0:
 					if bool(self.flip_x) != self._settings.get_boolean(["flipX"]):
-						new_line = [new_line[1], new_line[0], new_line[2]]
+						new_line.reverse()
 					self.mesh.append(new_line)
 
 			elif self.regex_catmull.match(line.strip()):

--- a/octoprint_bedlevelvisualizer/__init__.py
+++ b/octoprint_bedlevelvisualizer/__init__.py
@@ -205,8 +205,6 @@ class bedlevelvisualizer(octoprint.plugin.StartupPlugin,
 				if self._settings.get_boolean(["stripFirst"]):
 					new_line.pop(0)
 				if len(new_line) > 0:
-					if bool(self.flip_x) != self._settings.get_boolean(["flipX"]):
-						new_line.reverse()
 					self.mesh.append(new_line)
 
 			elif self.regex_catmull.match(line.strip()):
@@ -293,6 +291,11 @@ class bedlevelvisualizer(octoprint.plugin.StartupPlugin,
 				self._bedlevelvisualizer_logger.debug(self.mesh)
 
 			self._bedlevelvisualizer_logger.debug("stopping mesh collection")
+
+			if bool(self.flip_x) != bool(self._settings.get(["flipX"])):
+				self._bedlevelvisualizer_logger.debug("flipping x axis")
+				self.mesh = np.flip(np.array(self.mesh), 1).tolist()
+
 			if bool(self.flip_y) != bool(self._settings.get(["flipY"])):
 				self._bedlevelvisualizer_logger.debug("flipping y axis")
 				self.mesh.reverse()

--- a/octoprint_bedlevelvisualizer/__init__.py
+++ b/octoprint_bedlevelvisualizer/__init__.py
@@ -206,7 +206,7 @@ class bedlevelvisualizer(octoprint.plugin.StartupPlugin,
 					new_line.pop(0)
 				if len(new_line) > 0:
 					if bool(self.flip_x) != self._settings.get_boolean(["flipX"]):
-						new_line.reverse()
+						new_line = [new_line[1], new_line[0], new_line[2]]
 					self.mesh.append(new_line)
 
 			elif self.regex_catmull.match(line.strip()):


### PR DESCRIPTION
This resolves issue #185. 

In the previous code, new_line.reverse() didn't flip the x axis, it resorted the distortion matrix so that x, y, z -> z, y, x. Later, when the mesh was processed, this sometimes resulted in the following error due to unique() being called on the z data, which could have duplicate values.

```
2020-08-04 17:49:54,432 - octoprint.util.comm - ERROR - Error while processing hook bedlevelvisualizer:
Traceback (most recent call last):
  File "/home/pi/oprint/local/lib/python2.7/site-packages/octoprint/util/comm.py", line 2849, in _readline
    ret = hook(self, ret)
  File "/home/pi/OctoPrint-BedLevelVisualizer/octoprint_bedlevelvisualizer/__init__.py", line 283, in process_gcode
    z = a[2].reshape((len(x), len(y)))
ValueError: cannot reshape array of size 25 into shape (24,5)
```

The fix waits until it's time to process the mesh and then uses np.flip() to correctly flip the x axis.