### PR TITLE
1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,17 +68,21 @@ For more info, see the [wiki](wiki/index.md)
 ---
 
 ## Most recent changelog
-**[1.0.0](https://github.com/jneilliii/OctoPrint-BedLevelVisualizer/releases/tag/1.0.0)** (10/10/2020)
+**[1.0.0](https://github.com/jneilliii/OctoPrint-BedLevelVisualizer/releases/tag/1.0.0)** (11/20/2020)
 
 **Added**
 * release channels for OctoPrint 1.5.0+ for future rc testing, similar to OctoPrint as described [here](https://community.octoprint.org/t/how-to-use-the-release-channels-to-help-test-release-candidates/402)
 
 **Updated**
 * think it's time to go to major version 1.0.0 now with over 19K known installs
+* knockout sortable library for OctoPrint 1.5.0 compatibility
 
 **Fixed**
+* knockout binding issue due to knockout version update to 3.5.1 in OctoPrint 1.5.0
 * issue relative to using center origins and odd numbered mesh grid
 * issue with misinterpretation of bed level correction matrix
+* typos in reverse direction hover text
+* turn direction label coloring when direction is reversed
 
 ## [All releases](https://github.com/jneilliii/OctoPrint-BedLevelVisualizer/releases)
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Check out my other plugins [here](https://plugins.octoprint.org/by_author/#jneil
 - @tideline3d
 - [SimplyPrint](https://simplyprint.dk/)
 - [Andrew Beeman](https://github.com/Kiendeleo)
+- [Calanish](https://github.com/calanish)
 
 ## Support My Efforts
 I, jneilliii, programmed this plugin for fun and do my best effort to support those that have issues with it, please return the favor and leave me a tip or become a Patron if you find this plugin helpful and want me to continue future development.

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Check out my other plugins [here](https://plugins.octoprint.org/by_author/#jneil
 - [@TheTuxKeeper](https://github.com/thetuxkeeper)
 - @tideline3d
 - [SimplyPrint](https://simplyprint.dk/)
+- [Andrew Beeman](https://github.com/Kiendeleo)
 
 ## Support My Efforts
 I, jneilliii, programmed this plugin for fun and do my best effort to support those that have issues with it, please return the favor and leave me a tip or become a Patron if you find this plugin helpful and want me to continue future development.

--- a/README.md
+++ b/README.md
@@ -68,24 +68,17 @@ For more info, see the [wiki](wiki/index.md)
 ---
 
 ## Most recent changelog
-**[0.1.15](https://github.com/jneilliii/OctoPrint-BedLevelVisualizer/releases/tag/0.1.15)** (10/2/2020)
+**[1.0.0](https://github.com/jneilliii/OctoPrint-BedLevelVisualizer/releases/tag/1.0.0)** (10/10/2020)
 
 **Added**
-* automatic snapshot saving of graph on graph rendering
-* initial SD card support to trigger mesh colletion
-* auto option for colorscale that will work the same as prior to version 0.1.14
-* axis zeroline color
+* release channels for OctoPrint 1.5.0+ for future rc testing, similar to OctoPrint as described [here](https://community.octoprint.org/t/how-to-use-the-release-channels-to-help-test-release-candidates/402)
 
 **Updated**
-* plotly js library to version 1.54.7
-* numpy version requirement to improve installation speed in python 3
+* think it's time to go to major version 1.0.0 now with over 19K known installs
 
 **Fixed**
-* axis labels colors were reversed
-* graph not rerendering on window resize, made responsive
-* home button not working properly
-* repetier issues introduced in version 0.1.14
-* fix x axis flip issue
+* issue relative to using center origins and odd numbered mesh grid
+* issue with misinterpretation of bed level correction matrix
 
 ## [All releases](https://github.com/jneilliii/OctoPrint-BedLevelVisualizer/releases)
 

--- a/octoprint_bedlevelvisualizer/__init__.py
+++ b/octoprint_bedlevelvisualizer/__init__.py
@@ -160,7 +160,7 @@ class bedlevelvisualizer(
         return dict(
             js=[
                 "js/jquery-ui.min.js",
-                "js/knockout-sortable.js",
+                "js/knockout-sortable.1.2.0.js",
                 "js/fontawesome-iconpicker.js",
                 "js/ko.iconpicker.js",
                 "js/plotly.min.js",

--- a/octoprint_bedlevelvisualizer/__init__.py
+++ b/octoprint_bedlevelvisualizer/__init__.py
@@ -12,402 +12,478 @@ import flask
 import json
 
 
-class bedlevelvisualizer(octoprint.plugin.StartupPlugin,
-						 octoprint.plugin.TemplatePlugin,
-						 octoprint.plugin.AssetPlugin,
-						 octoprint.plugin.SettingsPlugin,
-						 octoprint.plugin.WizardPlugin,
-						 octoprint.plugin.SimpleApiPlugin,
-						 octoprint.plugin.EventHandlerPlugin):
-	INTERVAL = 2.0
-	MAX_HISTORY = 10
+class bedlevelvisualizer(
+    octoprint.plugin.StartupPlugin,
+    octoprint.plugin.TemplatePlugin,
+    octoprint.plugin.AssetPlugin,
+    octoprint.plugin.SettingsPlugin,
+    octoprint.plugin.WizardPlugin,
+    octoprint.plugin.SimpleApiPlugin,
+    octoprint.plugin.EventHandlerPlugin,
+):
+    INTERVAL = 2.0
+    MAX_HISTORY = 10
 
-	def __init__(self):
-		self.processing = False
-		self.printing = False
-		self.mesh_collection_canceled = False
-		self.old_marlin = False
-		self.makergear = False
-		self.old_marlin_offset = 0
-		self.repetier_firmware = False
-		self.mesh = []
-		self.box = []
-		self.flip_x = False
-		self.flip_y = False
-		self._logger = logging.getLogger("octoprint.plugins.bedlevelvisualizer")
-		self._bedlevelvisualizer_logger = logging.getLogger("octoprint.plugins.bedlevelvisualizer.debug")
-		self.regex_mesh_data = re.compile(
-			r"^((G33.+)|(Bed.+)|(Llit.+)|(\d+\s)|(\|\s*)|(\s*\[\s+)|(\[?\s?\+?-?\d?\.\d+\]?\s*,?)|(\s?\.\s*)|(NAN,"
-			r"?)|(nan\s?,?)|(=======\s?,?))+(\s+\],?)?$")
-		self.regex_bed_level_correction = re.compile(r"^(Mesh )?Bed Level (Correction Matrix|data):.*$")
-		self.regex_nans = re.compile(r"^(nan\s?,?)+$")
-		self.regex_equal_signs = re.compile(r"^(=======\s?,?)+$")
-		self.regex_mesh_data_extraction = re.compile(r"(\+?-?\d*\.\d*)")
-		self.regex_old_marlin = re.compile(r"^(Bed x:.+)|(Llit x:.+)$")
-		self.regex_makergear = re.compile(r"^(\s=\s\[)(\s*,?\s*\[(\s?-?\d+.\d+,?)+\])+\];?$")
-		self.regex_repetier = re.compile(r"^G33 X.+$")
-		self.regex_nan = re.compile(r"(nan)")
-		self.regex_catmull = re.compile(r"^Subdivided with CATMULL ROM Leveling Grid:.*$")
-		self.regex_extracted_box = re.compile(r"\(\s*(\d+),\s*(\d+)\)")
-		self.regex_eqn_coefficients = re.compile(r"^Eqn coefficients:.+$")
-		self.regex_unknown_command = re.compile(r"echo:Unknown command: \"@BEDLEVELVISUALIZER\"")
+    def __init__(self):
+        self.processing = False
+        self.printing = False
+        self.mesh_collection_canceled = False
+        self.old_marlin = False
+        self.makergear = False
+        self.old_marlin_offset = 0
+        self.repetier_firmware = False
+        self.mesh = []
+        self.box = []
+        self.flip_x = False
+        self.flip_y = False
+        self._logger = logging.getLogger("octoprint.plugins.bedlevelvisualizer")
+        self._bedlevelvisualizer_logger = logging.getLogger(
+            "octoprint.plugins.bedlevelvisualizer.debug"
+        )
+        self.regex_mesh_data = re.compile(
+            r"^((G33.+)|(Bed.+)|(Llit.+)|(\d+\s)|(\|\s*)|(\s*\[\s+)|(\[?\s?\+?-?\d?\.\d+\]?\s*,?)|(\s?\.\s*)|(NAN,"
+            r"?)|(nan\s?,?)|(=======\s?,?))+(\s+\],?)?$"
+        )
+        self.regex_bed_level_correction = re.compile(
+            r"^(Mesh )?Bed Level (Correction Matrix|data):.*$"
+        )
+        self.regex_nans = re.compile(r"^(nan\s?,?)+$")
+        self.regex_equal_signs = re.compile(r"^(=======\s?,?)+$")
+        self.regex_mesh_data_extraction = re.compile(r"(\+?-?\d*\.\d*)")
+        self.regex_old_marlin = re.compile(r"^(Bed x:.+)|(Llit x:.+)$")
+        self.regex_makergear = re.compile(
+            r"^(\s=\s\[)(\s*,?\s*\[(\s?-?\d+.\d+,?)+\])+\];?$"
+        )
+        self.regex_repetier = re.compile(r"^G33 X.+$")
+        self.regex_nan = re.compile(r"(nan)")
+        self.regex_catmull = re.compile(
+            r"^Subdivided with CATMULL ROM Leveling Grid:.*$"
+        )
+        self.regex_extracted_box = re.compile(r"\(\s*(\d+),\s*(\d+)\)")
+        self.regex_eqn_coefficients = re.compile(r"^Eqn coefficients:.+$")
+        self.regex_unknown_command = re.compile(
+            r"echo:Unknown command: \"@BEDLEVELVISUALIZER\""
+        )
 
-	# SettingsPlugin
+    # SettingsPlugin
 
-	def get_settings_defaults(self):
-		return dict(command="",
-					stored_mesh=[],
-					stored_mesh_x=[],
-					stored_mesh_y=[],
-					stored_mesh_z_height=2,
-					save_mesh=True,
-					mesh_timestamp="",
-					flipX=False,
-					flipY=False,
-					stripFirst=False,
-					use_center_origin=False,
-					use_relative_offsets=False,
-					timeout=1800,
-					rotation=0,
-					ignore_correction_matrix=False,
-					screw_hub=0.5,
-					mesh_unit=1,
-					reverse=False,
-					showdegree=False,
-					imperial=False,
-					descending_y=False,
-					descending_x=False,
-					debug_logging=False,
-					commands=[],
-					show_labels=True,
-					show_webcam=False,
-					graph_z_limits="-2,2",
-					colorscale="[[0, \"rebeccapurple\"],[0.4, \"rebeccapurple\"],[0.45, \"blue\"],[0.5, \"green\"],[0.55, \"yellow\"],[0.6, \"red\"],[1, \"red\"]]",
-					save_snapshots=False)
+    def get_settings_defaults(self):
+        return dict(
+            command="",
+            stored_mesh=[],
+            stored_mesh_x=[],
+            stored_mesh_y=[],
+            stored_mesh_z_height=2,
+            save_mesh=True,
+            mesh_timestamp="",
+            flipX=False,
+            flipY=False,
+            stripFirst=False,
+            use_center_origin=False,
+            use_relative_offsets=False,
+            timeout=1800,
+            rotation=0,
+            ignore_correction_matrix=False,
+            screw_hub=0.5,
+            mesh_unit=1,
+            reverse=False,
+            showdegree=False,
+            imperial=False,
+            descending_y=False,
+            descending_x=False,
+            debug_logging=False,
+            commands=[],
+            show_labels=True,
+            show_webcam=False,
+            graph_z_limits="-2,2",
+            colorscale='[[0, "rebeccapurple"],[0.4, "rebeccapurple"],[0.45, "blue"],[0.5, "green"],[0.55, "yellow"],[0.6, "red"],[1, "red"]]',
+            save_snapshots=False,
+        )
 
-	def get_settings_version(self):
-		return 1
+    def get_settings_version(self):
+        return 1
 
-	def on_settings_migrate(self, target, current=None):
-		if current is None or current < 1:
-			# Loop through commands adding new fields
-			commands_new = []
-			self._logger.info(self._settings.get(['commands']))
-			for command in self._settings.get(['commands']):
-				command["confirmation"] = False
-				command["input"] = []
-				command["message"] = ""
-				commands_new.append(command)
-			self._settings.set(["commands"], commands_new)
+    def on_settings_migrate(self, target, current=None):
+        if current is None or current < 1:
+            # Loop through commands adding new fields
+            commands_new = []
+            self._logger.info(self._settings.get(["commands"]))
+            for command in self._settings.get(["commands"]):
+                command["confirmation"] = False
+                command["input"] = []
+                command["message"] = ""
+                commands_new.append(command)
+            self._settings.set(["commands"], commands_new)
 
-	def on_settings_save(self, data):
-		old_debug_logging = self._settings.get_boolean(["debug_logging"])
+    def on_settings_save(self, data):
+        old_debug_logging = self._settings.get_boolean(["debug_logging"])
 
-		octoprint.plugin.SettingsPlugin.on_settings_save(self, data)
+        octoprint.plugin.SettingsPlugin.on_settings_save(self, data)
 
-		new_debug_logging = self._settings.get_boolean(["debug_logging"])
-		if old_debug_logging != new_debug_logging:
-			if new_debug_logging:
-				self._bedlevelvisualizer_logger.setLevel(logging.DEBUG)
-			else:
-				self._bedlevelvisualizer_logger.setLevel(logging.INFO)
+        new_debug_logging = self._settings.get_boolean(["debug_logging"])
+        if old_debug_logging != new_debug_logging:
+            if new_debug_logging:
+                self._bedlevelvisualizer_logger.setLevel(logging.DEBUG)
+            else:
+                self._bedlevelvisualizer_logger.setLevel(logging.INFO)
 
-	# StartupPlugin
+    # StartupPlugin
 
-	def on_startup(self, host, port):
-		# setup customized logger
-		from octoprint.logging.handlers import CleaningTimedRotatingFileHandler
-		bedlevelvisualizer_logging_handler = CleaningTimedRotatingFileHandler(
-			self._settings.get_plugin_logfile_path(postfix="debug"), when="D", backupCount=3)
-		bedlevelvisualizer_logging_handler.setFormatter(logging.Formatter("[%(asctime)s] %(levelname)s: %(message)s"))
-		bedlevelvisualizer_logging_handler.setLevel(logging.DEBUG)
+    def on_startup(self, host, port):
+        # setup customized logger
+        from octoprint.logging.handlers import CleaningTimedRotatingFileHandler
 
-		self._bedlevelvisualizer_logger.addHandler(bedlevelvisualizer_logging_handler)
-		self._bedlevelvisualizer_logger.setLevel(
-			logging.DEBUG if self._settings.get_boolean(["debug_logging"]) else logging.INFO)
-		self._bedlevelvisualizer_logger.propagate = False
+        bedlevelvisualizer_logging_handler = CleaningTimedRotatingFileHandler(
+            self._settings.get_plugin_logfile_path(postfix="debug"),
+            when="D",
+            backupCount=3,
+        )
+        bedlevelvisualizer_logging_handler.setFormatter(
+            logging.Formatter("[%(asctime)s] %(levelname)s: %(message)s")
+        )
+        bedlevelvisualizer_logging_handler.setLevel(logging.DEBUG)
 
-	def on_after_startup(self):
-		self._logger.info("OctoPrint-BedLevelVisualizer loaded!")
+        self._bedlevelvisualizer_logger.addHandler(bedlevelvisualizer_logging_handler)
+        self._bedlevelvisualizer_logger.setLevel(
+            logging.DEBUG
+            if self._settings.get_boolean(["debug_logging"])
+            else logging.INFO
+        )
+        self._bedlevelvisualizer_logger.propagate = False
 
-	# AssetPlugin
+    def on_after_startup(self):
+        self._logger.info("OctoPrint-BedLevelVisualizer loaded!")
 
-	def get_assets(self):
-		return dict(
-			js=["js/jquery-ui.min.js", "js/knockout-sortable.js", "js/fontawesome-iconpicker.js", "js/ko.iconpicker.js",
-				"js/plotly.min.js", "js/bedlevelvisualizer.js"],
-			css=["css/font-awesome.min.css", "css/font-awesome-v4-shims.min.css", "css/fontawesome-iconpicker.css",
-				 "css/bedlevelvisualizer.css"]
-		)
+    # AssetPlugin
 
-	# EventHandlePlugin
+    def get_assets(self):
+        return dict(
+            js=[
+                "js/jquery-ui.min.js",
+                "js/knockout-sortable.js",
+                "js/fontawesome-iconpicker.js",
+                "js/ko.iconpicker.js",
+                "js/plotly.min.js",
+                "js/bedlevelvisualizer.js",
+            ],
+            css=[
+                "css/font-awesome.min.css",
+                "css/font-awesome-v4-shims.min.css",
+                "css/fontawesome-iconpicker.css",
+                "css/bedlevelvisualizer.css",
+            ],
+        )
 
-	def on_event(self, event, payload):
-		# Cancelled Print Interpreted Event
-		if event == Events.PRINT_FAILED and not self._printer.is_closed_or_error():
-			self.printing = False
-		# Print Started Event
-		if event == Events.PRINT_STARTED:
-			self.printing = True
-		# Print Done Event
-		if event == Events.PRINT_DONE:
-			self.printing = False
+    # EventHandlePlugin
 
-	# atcommand hook
+    def on_event(self, event, payload):
+        # Cancelled Print Interpreted Event
+        if event == Events.PRINT_FAILED and not self._printer.is_closed_or_error():
+            self.printing = False
+        # Print Started Event
+        if event == Events.PRINT_STARTED:
+            self.printing = True
+        # Print Done Event
+        if event == Events.PRINT_DONE:
+            self.printing = False
 
-	def enable_mesh_collection(self):
-		self.mesh = []
-		self.box = []
-		self._bedlevelvisualizer_logger.debug("mesh collection started")
-		self.processing = True
-		self._plugin_manager.send_plugin_message(self._identifier, dict(processing=True))
+    # atcommand hook
 
-	def flag_mesh_collection(self, comm_instance, phase, command, parameters, tags=None, *args, **kwargs):
-		if command == 'BEDLEVELVISUALIZER':
-			thread = threading.Thread(target=self.enable_mesh_collection)
-			thread.daemon = True
-			thread.start()
-		return
+    def enable_mesh_collection(self):
+        self.mesh = []
+        self.box = []
+        self._bedlevelvisualizer_logger.debug("mesh collection started")
+        self.processing = True
+        self._plugin_manager.send_plugin_message(
+            self._identifier, dict(processing=True)
+        )
 
-	def process_gcode(self, comm, line, *args, **kwargs):
-		if self.printing and line.strip() == "echo:BEDLEVELVISUALIZER":
-			thread = threading.Thread(target=self.enable_mesh_collection)
-			thread.daemon = True
-			thread.start()
-			return line
-		if not self.processing:
-			return line
+    def flag_mesh_collection(
+        self, comm_instance, phase, command, parameters, tags=None, *args, **kwargs
+    ):
+        if command == "BEDLEVELVISUALIZER":
+            thread = threading.Thread(target=self.enable_mesh_collection)
+            thread.daemon = True
+            thread.start()
+        return
 
-		if self._settings.get_boolean(["ignore_correction_matrix"]) and self.regex_bed_level_correction.match(
-			line.strip()):
-			line = "ok"
+    def process_gcode(self, comm, line, *args, **kwargs):
+        if self.printing and line.strip() == "echo:BEDLEVELVISUALIZER":
+            thread = threading.Thread(target=self.enable_mesh_collection)
+            thread.daemon = True
+            thread.start()
+            return line
+        if not self.processing:
+            return line
 
-		if "ok" not in line:
-			if self.regex_mesh_data.match(line.strip()):
-				if self.regex_bed_level_correction.match(line.strip()) and not self._settings.get_boolean(["ignore_correction_matrix"]):
-					self._bedlevelvisualizer_logger.debug("resetting mesh to blank because of correction matrix")
-					self.mesh = []
-					return line
-				if self.regex_nans.match(line.strip()):
-					self._bedlevelvisualizer_logger.debug("stupid smoothieware issue...")
-					line = self.regex_nan.sub("0.0", line)
-				if self.regex_equal_signs.match(line.strip()):
-					self._bedlevelvisualizer_logger.debug("stupid equal signs...")
-					line = self.regex_equal_signs.sub("0.0", line)
+        if self._settings.get_boolean(
+            ["ignore_correction_matrix"]
+        ) and self.regex_bed_level_correction.match(line.strip()):
+            line = "ok"
 
-				new_line = self.regex_mesh_data_extraction.findall(line)
-				self._bedlevelvisualizer_logger.debug(new_line)
+        if "ok" not in line:
+            if self.regex_mesh_data.match(line.strip()):
+                if self.regex_bed_level_correction.match(
+                    line.strip()
+                ) and not self._settings.get_boolean(["ignore_correction_matrix"]):
+                    self._bedlevelvisualizer_logger.debug(
+                        "resetting mesh to blank because of correction matrix"
+                    )
+                    self.mesh = []
+                    return line
+                if self.regex_nans.match(line.strip()):
+                    self._bedlevelvisualizer_logger.debug(
+                        "stupid smoothieware issue..."
+                    )
+                    line = self.regex_nan.sub("0.0", line)
+                if self.regex_equal_signs.match(line.strip()):
+                    self._bedlevelvisualizer_logger.debug("stupid equal signs...")
+                    line = self.regex_equal_signs.sub("0.0", line)
 
-				if self.regex_old_marlin.match(line.strip()):
-					self.old_marlin = True
-					self._bedlevelvisualizer_logger.debug("using old marlin flag")
+                new_line = self.regex_mesh_data_extraction.findall(line)
+                self._bedlevelvisualizer_logger.debug(new_line)
 
-				if self.regex_repetier.match(line.strip()):
-					self.repetier_firmware = True
-					self._bedlevelvisualizer_logger.debug("using repetier flag")
+                if self.regex_old_marlin.match(line.strip()):
+                    self.old_marlin = True
+                    self._bedlevelvisualizer_logger.debug("using old marlin flag")
 
-				if self._settings.get_boolean(["stripFirst"]):
-					new_line.pop(0)
-				if len(new_line) > 0:
-					self.mesh.append(new_line)
+                if self.regex_repetier.match(line.strip()):
+                    self.repetier_firmware = True
+                    self._bedlevelvisualizer_logger.debug("using repetier flag")
 
-			elif self.regex_catmull.match(line.strip()):
-				self._bedlevelvisualizer_logger.debug("resetting mesh to blank because of CATMULL subdivision")
-				self.mesh = []
+                if self._settings.get_boolean(["stripFirst"]):
+                    new_line.pop(0)
+                if len(new_line) > 0:
+                    self.mesh.append(new_line)
 
-			elif self.regex_extracted_box.findall(line.strip()):
-				box = self.regex_extracted_box.findall(line.strip())
-				if len(box) == 2:
-					self.box += [[float(x), float(y)] for x, y in box]
-				if len(self.box) == 2:
-					if self.box[0][0] > self.box[1][0]:
-						self.flip_x = True
-				if len(self.box) == 4:
-					if self.box[0][1] > self.box[3][1]:
-						self.flip_y = True
+            elif self.regex_catmull.match(line.strip()):
+                self._bedlevelvisualizer_logger.debug(
+                    "resetting mesh to blank because of CATMULL subdivision"
+                )
+                self.mesh = []
 
-			if self.regex_makergear.match(line) is not None:
-				self._bedlevelvisualizer_logger.debug("using makergear format report")
-				self.mesh = json.loads(line.strip().replace("= ", "").replace(";", ""))
-				self.old_marlin = True
-				self.makergear = True
-				self._bedlevelvisualizer_logger.debug(self.mesh)
-				line = "ok"
+            elif self.regex_extracted_box.findall(line.strip()):
+                box = self.regex_extracted_box.findall(line.strip())
+                if len(box) == 2:
+                    self.box += [[float(x), float(y)] for x, y in box]
+                if len(self.box) == 2:
+                    if self.box[0][0] > self.box[1][0]:
+                        self.flip_x = True
+                if len(self.box) == 4:
+                    if self.box[0][1] > self.box[3][1]:
+                        self.flip_y = True
 
-			if self.old_marlin and self.regex_eqn_coefficients.match(line.strip()):
-				self.old_marlin_offset = self.regex_eqn_coefficients.sub(r"\2", line.strip())
-				self._bedlevelvisualizer_logger.debug("using old marlin offset")
+            if self.regex_makergear.match(line) is not None:
+                self._bedlevelvisualizer_logger.debug("using makergear format report")
+                self.mesh = json.loads(line.strip().replace("= ", "").replace(";", ""))
+                self.old_marlin = True
+                self.makergear = True
+                self._bedlevelvisualizer_logger.debug(self.mesh)
+                line = "ok"
 
-			if "Home XYZ first" in line or "Invalid mesh" in line:
-				reason = "data is invalid" if "Invalid" in line else "homing required"
-				self._bedlevelvisualizer_logger.debug("stopping mesh collection because %s" % reason)
+            if self.old_marlin and self.regex_eqn_coefficients.match(line.strip()):
+                self.old_marlin_offset = self.regex_eqn_coefficients.sub(
+                    r"\2", line.strip()
+                )
+                self._bedlevelvisualizer_logger.debug("using old marlin offset")
 
-			if "Home XYZ first" in line:
-				self._plugin_manager.send_plugin_message(self._identifier, dict(error=line.strip()))
-				self.processing = False
+            if "Home XYZ first" in line or "Invalid mesh" in line:
+                reason = "data is invalid" if "Invalid" in line else "homing required"
+                self._bedlevelvisualizer_logger.debug(
+                    "stopping mesh collection because %s" % reason
+                )
 
-		if ("ok" in line or (self.repetier_firmware and "T:" in line)) and len(self.mesh) > 0:
-			octoprint_printer_profile = self._printer_profile_manager.get_current()
-			volume = octoprint_printer_profile["volume"]
-			bed_type = volume["formFactor"]
-			custom_box = volume["custom_box"]
-			# see if we have a custom bounding box
-			if custom_box:
-				min_x = custom_box["x_min"]
-				max_x = custom_box["x_max"]
-				min_y = custom_box["y_min"]
-				max_y = custom_box["y_max"]
-				min_z = custom_box["z_min"]
-				max_z = custom_box["z_max"]
-			else:
-				min_x = 0
-				max_x = volume["width"]
-				min_y = 0
-				max_y = volume["depth"]
-				min_z = 0
-				max_z = volume["height"]
-			if len(self.box) == 4:
-				min_x = min([x for x, y in self.box])
-				max_x = max([x for x, y in self.box])
-				min_y = min([y for x, y in self.box])
-				max_y = max([y for x, y in self.box])
+            if "Home XYZ first" in line:
+                self._plugin_manager.send_plugin_message(
+                    self._identifier, dict(error=line.strip())
+                )
+                self.processing = False
 
-			bed = dict(type=bed_type, x_min=min_x, x_max=max_x, y_min=min_y, y_max=max_y, z_min=min_z, z_max=max_z)
-			self._bedlevelvisualizer_logger.debug(bed)
+        if ("ok" in line or (self.repetier_firmware and "T:" in line)) and len(
+            self.mesh
+        ) > 0:
+            octoprint_printer_profile = self._printer_profile_manager.get_current()
+            volume = octoprint_printer_profile["volume"]
+            bed_type = volume["formFactor"]
+            custom_box = volume["custom_box"]
+            # see if we have a custom bounding box
+            if custom_box:
+                min_x = custom_box["x_min"]
+                max_x = custom_box["x_max"]
+                min_y = custom_box["y_min"]
+                max_y = custom_box["y_max"]
+                min_z = custom_box["z_min"]
+                max_z = custom_box["z_max"]
+            else:
+                min_x = 0
+                max_x = volume["width"]
+                min_y = 0
+                max_y = volume["depth"]
+                min_z = 0
+                max_z = volume["height"]
+            if len(self.box) == 4:
+                min_x = min([x for x, y in self.box])
+                max_x = max([x for x, y in self.box])
+                min_y = min([y for x, y in self.box])
+                max_y = max([y for x, y in self.box])
 
-			if self.old_marlin or self.repetier_firmware:
-				if not self.makergear:
-					a = np.swapaxes(self.mesh, 1, 0)
-				else:
-					a = np.array(self.mesh)
-				x = np.unique(a[0]).astype(np.float)
-				y = np.unique(a[1]).astype(np.float)
-				z = a[2].reshape((len(x), len(y)))
-				self._bedlevelvisualizer_logger.debug(a)
-				self._bedlevelvisualizer_logger.debug(x)
-				self._bedlevelvisualizer_logger.debug(y)
-				self._bedlevelvisualizer_logger.debug(z)
-				offset = 0
-				if self.old_marlin:
-					offset = self.old_marlin_offset
-				self._bedlevelvisualizer_logger.debug(offset)
-				self.mesh = np.subtract(z, [offset], dtype=np.float, casting='unsafe').tolist()
-				self._bedlevelvisualizer_logger.debug(self.mesh)
+            bed = dict(
+                type=bed_type,
+                x_min=min_x,
+                x_max=max_x,
+                y_min=min_y,
+                y_max=max_y,
+                z_min=min_z,
+                z_max=max_z,
+            )
+            self._bedlevelvisualizer_logger.debug(bed)
 
-			self._bedlevelvisualizer_logger.debug("stopping mesh collection")
+            if self.old_marlin or self.repetier_firmware:
+                if not self.makergear:
+                    a = np.swapaxes(self.mesh, 1, 0)
+                else:
+                    a = np.array(self.mesh)
+                x = np.unique(a[0]).astype(np.float)
+                y = np.unique(a[1]).astype(np.float)
+                z = a[2].reshape((len(x), len(y)))
+                self._bedlevelvisualizer_logger.debug(a)
+                self._bedlevelvisualizer_logger.debug(x)
+                self._bedlevelvisualizer_logger.debug(y)
+                self._bedlevelvisualizer_logger.debug(z)
+                offset = 0
+                if self.old_marlin:
+                    offset = self.old_marlin_offset
+                self._bedlevelvisualizer_logger.debug(offset)
+                self.mesh = np.subtract(
+                    z, [offset], dtype=np.float, casting="unsafe"
+                ).tolist()
+                self._bedlevelvisualizer_logger.debug(self.mesh)
 
-			if bool(self.flip_x) != bool(self._settings.get(["flipX"])):
-				self._bedlevelvisualizer_logger.debug("flipping x axis")
-				self.mesh = np.flip(np.array(self.mesh), 1).tolist()
+            self._bedlevelvisualizer_logger.debug("stopping mesh collection")
 
-			if bool(self.flip_y) != bool(self._settings.get(["flipY"])):
-				self._bedlevelvisualizer_logger.debug("flipping y axis")
-				self.mesh.reverse()
+            if bool(self.flip_x) != bool(self._settings.get(["flipX"])):
+                self._bedlevelvisualizer_logger.debug("flipping x axis")
+                self.mesh = np.flip(np.array(self.mesh), 1).tolist()
 
-			if self._settings.get_boolean(["use_relative_offsets"]):
-				self._bedlevelvisualizer_logger.debug("using relative offsets")
-				self.mesh = np.array(self.mesh)
-				if self._settings.get_boolean(["use_center_origin"]):
-					self._bedlevelvisualizer_logger.debug("using center origin")
-					self.mesh = np.subtract(self.mesh, self.mesh[len(self.mesh[0]) // 2, len(self.mesh) // 2],
-											dtype=np.float, casting='unsafe').tolist()
-				else:
-					self.mesh = np.subtract(self.mesh, self.mesh[0, 0], dtype=np.float, casting='unsafe').tolist()
+            if bool(self.flip_y) != bool(self._settings.get(["flipY"])):
+                self._bedlevelvisualizer_logger.debug("flipping y axis")
+                self.mesh.reverse()
 
-			if int(self._settings.get_int(["rotation"])) > 0:
-				self._bedlevelvisualizer_logger.debug("rotating mesh by %s" % self._settings.get(["rotation"]))
-				self.mesh = np.array(self.mesh)
-				self.mesh = np.rot90(self.mesh, self._settings.get_int(["rotation"]) / 90).tolist()
+            if self._settings.get_boolean(["use_relative_offsets"]):
+                self._bedlevelvisualizer_logger.debug("using relative offsets")
+                self.mesh = np.array(self.mesh)
+                if self._settings.get_boolean(["use_center_origin"]):
+                    self._bedlevelvisualizer_logger.debug("using center origin")
+                    self.mesh = np.subtract(
+                        self.mesh,
+                        self.mesh[len(self.mesh[0]) // 2, len(self.mesh) // 2],
+                        dtype=np.float,
+                        casting="unsafe",
+                    ).tolist()
+                else:
+                    self.mesh = np.subtract(
+                        self.mesh, self.mesh[0, 0], dtype=np.float, casting="unsafe"
+                    ).tolist()
 
-			if bed_type == "circular":
-				n = len(self.mesh[0])
-				m = len(self.mesh)
-				circle_mask = self.create_circular_mask(n, m)
-				self.mesh = np.array(self.mesh)
-				self.mesh[~circle_mask] = None
-				self.mesh = self.mesh.tolist()
-				self._bedlevelvisualizer_logger.debug(self.mesh)
+            if int(self._settings.get_int(["rotation"])) > 0:
+                self._bedlevelvisualizer_logger.debug(
+                    "rotating mesh by %s" % self._settings.get(["rotation"])
+                )
+                self.mesh = np.array(self.mesh)
+                self.mesh = np.rot90(
+                    self.mesh, self._settings.get_int(["rotation"]) / 90
+                ).tolist()
 
-			self.processing = False
-			self._bedlevelvisualizer_logger.debug(self.mesh)
-			self._plugin_manager.send_plugin_message(self._identifier, dict(mesh=self.mesh, bed=bed))
-			self.send_mesh_data_collected_event(self.mesh, bed)
+            if bed_type == "circular":
+                n = len(self.mesh[0])
+                m = len(self.mesh)
+                circle_mask = self.create_circular_mask(n, m)
+                self.mesh = np.array(self.mesh)
+                self.mesh[~circle_mask] = None
+                self.mesh = self.mesh.tolist()
+                self._bedlevelvisualizer_logger.debug(self.mesh)
 
-		return line
+            self.processing = False
+            self._bedlevelvisualizer_logger.debug(self.mesh)
+            self._plugin_manager.send_plugin_message(
+                self._identifier, dict(mesh=self.mesh, bed=bed)
+            )
+            self.send_mesh_data_collected_event(self.mesh, bed)
 
-	def create_circular_mask(self, h, w, center=None, radius=None):
-		if center is None:  # use the middle of the image
-			center = (int(w / 2), int(h / 2))
-		if radius is None:  # use the smallest distance between the center and image walls
-			radius = min(center[0], center[1], w - center[0], h - center[1])
+        return line
 
-		Y, X = np.ogrid[:h, :w]
-		dist_from_center = np.sqrt((X - center[0]) ** 2 + (Y - center[1]) ** 2)
+    def create_circular_mask(self, h, w, center=None, radius=None):
+        if center is None:  # use the middle of the image
+            center = (int(w / 2), int(h / 2))
+        if (
+            radius is None
+        ):  # use the smallest distance between the center and image walls
+            radius = min(center[0], center[1], w - center[0], h - center[1])
 
-		mask = dist_from_center <= radius
-		return mask
+        Y, X = np.ogrid[:h, :w]
+        dist_from_center = np.sqrt((X - center[0]) ** 2 + (Y - center[1]) ** 2)
 
-	# SimpleApiPlugin
+        mask = dist_from_center <= radius
+        return mask
 
-	def get_api_commands(self):
-		return dict(stopProcessing=[])
+    # SimpleApiPlugin
 
-	def on_api_get(self, request):
-		if request.args.get("stopProcessing"):
-			self._bedlevelvisualizer_logger.debug("Canceling mesh collection per user request")
-			self._bedlevelvisualizer_logger.debug("Mesh data collected prior to cancel:")
-			self._bedlevelvisualizer_logger.debug(self.mesh)
-			self.processing = False
-			self.mesh_collection_canceled = True
-			self.mesh = []
-			self._bedlevelvisualizer_logger.debug("Mesh data after clearing:")
-			self._bedlevelvisualizer_logger.debug(self.mesh)
-			response = dict(stopped=True)
-			return flask.jsonify(response)
+    def get_api_commands(self):
+        return dict(stopProcessing=[])
 
-	# Custom Event Hook
+    def on_api_get(self, request):
+        if request.args.get("stopProcessing"):
+            self._bedlevelvisualizer_logger.debug(
+                "Canceling mesh collection per user request"
+            )
+            self._bedlevelvisualizer_logger.debug(
+                "Mesh data collected prior to cancel:"
+            )
+            self._bedlevelvisualizer_logger.debug(self.mesh)
+            self.processing = False
+            self.mesh_collection_canceled = True
+            self.mesh = []
+            self._bedlevelvisualizer_logger.debug("Mesh data after clearing:")
+            self._bedlevelvisualizer_logger.debug(self.mesh)
+            response = dict(stopped=True)
+            return flask.jsonify(response)
 
-	def send_mesh_data_collected_event(self, mesh_data, bed_data):
-		event = Events.PLUGIN_BEDLEVELVISUALIZER_MESH_DATA_COLLECTED
-		custom_payload = dict(
-			mesh=mesh_data,
-			bed=bed_data
-		)
-		self._event_bus.fire(event, payload=custom_payload)
+    # Custom Event Hook
 
-	def register_custom_events(*args, **kwargs):
-		return ["mesh_data_collected"]
+    def send_mesh_data_collected_event(self, mesh_data, bed_data):
+        event = Events.PLUGIN_BEDLEVELVISUALIZER_MESH_DATA_COLLECTED
+        custom_payload = dict(mesh=mesh_data, bed=bed_data)
+        self._event_bus.fire(event, payload=custom_payload)
 
-	# Software Update Hook
+    def register_custom_events(*args, **kwargs):
+        return ["mesh_data_collected"]
 
-	def get_update_information(self):
-		return dict(
-			bedlevelvisualizer=dict(
-				displayName="Bed Visualizer",
-				displayVersion=self._plugin_version,
+    # Software Update Hook
 
-				# version check: github repository
-				type="github_release",
-				user="jneilliii",
-				repo="OctoPrint-BedLevelVisualizer",
-				current=self._plugin_version,
-				stable_branch=dict(
-					name="Stable",
-					branch="master",
-					comittish=["master"]
-				),
-				prerelease_branches=[
-					dict(
-						name="Release Candidate",
-						branch="rc",
-						comittish=["rc", "master"]
-					)
-				],
-
-				# update method: pip
-				pip="https://github.com/jneilliii/OctoPrint-BedLevelVisualizer/archive/{target_version}.zip"
-			)
-		)
+    def get_update_information(self):
+        return dict(
+            bedlevelvisualizer=dict(
+                displayName="Bed Visualizer",
+                displayVersion=self._plugin_version,
+                # version check: github repository
+                type="github_release",
+                user="jneilliii",
+                repo="OctoPrint-BedLevelVisualizer",
+                current=self._plugin_version,
+                stable_branch=dict(
+                    name="Stable", branch="master", comittish=["master"]
+                ),
+                prerelease_branches=[
+                    dict(
+                        name="Release Candidate",
+                        branch="rc",
+                        comittish=["rc", "master"],
+                    )
+                ],
+                # update method: pip
+                pip="https://github.com/jneilliii/OctoPrint-BedLevelVisualizer/archive/{target_version}.zip",
+            )
+        )
 
 
 __plugin_name__ = "Bed Visualizer"
@@ -415,13 +491,13 @@ __plugin_pythoncompat__ = ">=2.7,<4"
 
 
 def __plugin_load__():
-	global __plugin_implementation__
-	__plugin_implementation__ = bedlevelvisualizer()
+    global __plugin_implementation__
+    __plugin_implementation__ = bedlevelvisualizer()
 
-	global __plugin_hooks__
-	__plugin_hooks__ = {
-		"octoprint.comm.protocol.atcommand.sending": __plugin_implementation__.flag_mesh_collection,
-		"octoprint.comm.protocol.gcode.received": __plugin_implementation__.process_gcode,
-		"octoprint.events.register_custom_events": __plugin_implementation__.register_custom_events,
-		"octoprint.plugin.softwareupdate.check_config": __plugin_implementation__.get_update_information
-	}
+    global __plugin_hooks__
+    __plugin_hooks__ = {
+        "octoprint.comm.protocol.atcommand.sending": __plugin_implementation__.flag_mesh_collection,
+        "octoprint.comm.protocol.gcode.received": __plugin_implementation__.process_gcode,
+        "octoprint.events.register_custom_events": __plugin_implementation__.register_custom_events,
+        "octoprint.plugin.softwareupdate.check_config": __plugin_implementation__.get_update_information,
+    }

--- a/octoprint_bedlevelvisualizer/__init__.py
+++ b/octoprint_bedlevelvisualizer/__init__.py
@@ -184,6 +184,10 @@ class bedlevelvisualizer(octoprint.plugin.StartupPlugin,
 
 		if "ok" not in line:
 			if self.regex_mesh_data.match(line.strip()):
+				if self.regex_bed_level_correction.match(line.strip()) and not self._settings.get_boolean(["ignore_correction_matrix"]):
+					self._bedlevelvisualizer_logger.debug("resetting mesh to blank because of correction matrix")
+					self.mesh = []
+					return line
 				if self.regex_nans.match(line.strip()):
 					self._bedlevelvisualizer_logger.debug("stupid smoothieware issue...")
 					line = self.regex_nan.sub("0.0", line)
@@ -305,7 +309,7 @@ class bedlevelvisualizer(octoprint.plugin.StartupPlugin,
 				self.mesh = np.array(self.mesh)
 				if self._settings.get_boolean(["use_center_origin"]):
 					self._bedlevelvisualizer_logger.debug("using center origin")
-					self.mesh = np.subtract(self.mesh, self.mesh[len(self.mesh[0]) / 2, len(self.mesh) / 2],
+					self.mesh = np.subtract(self.mesh, self.mesh[len(self.mesh[0]) // 2, len(self.mesh) // 2],
 											dtype=np.float, casting='unsafe').tolist()
 				else:
 					self.mesh = np.subtract(self.mesh, self.mesh[0, 0], dtype=np.float, casting='unsafe').tolist()
@@ -387,6 +391,18 @@ class bedlevelvisualizer(octoprint.plugin.StartupPlugin,
 				user="jneilliii",
 				repo="OctoPrint-BedLevelVisualizer",
 				current=self._plugin_version,
+				stable_branch=dict(
+					name="Stable",
+					branch="master",
+					comittish=["master"]
+				),
+				prerelease_branches=[
+					dict(
+						name="Release Candidate",
+						branch="rc",
+						comittish=["rc", "master"]
+					)
+				],
 
 				# update method: pip
 				pip="https://github.com/jneilliii/OctoPrint-BedLevelVisualizer/archive/{target_version}.zip"

--- a/octoprint_bedlevelvisualizer/static/js/bedlevelvisualizer.js
+++ b/octoprint_bedlevelvisualizer/static/js/bedlevelvisualizer.js
@@ -108,6 +108,8 @@ $(function () {
 			self.settingsViewModel.settings.plugins.bedlevelvisualizer.descending_x(self.descending_x());
 			self.settingsViewModel.settings.plugins.bedlevelvisualizer.descending_y(self.descending_y());
 			if(self.settingsViewModel.settings.plugins.bedlevelvisualizer.colorscale().length === 0) self.settingsViewModel.settings.plugins.bedlevelvisualizer.colorscale('[[0, "rebeccapurple"],[0.4, "rebeccapurple"],[0.45, "blue"],[0.5, "green"],[0.55, "yellow"],[0.6, "red"],[1, "red"]]');
+			if(self.settingsViewModel.settings.plugins.bedlevelvisualizer.rotation().length === 0) self.settingsViewModel.settings.plugins.bedlevelvisualizer.rotation(0);
+			if(self.settingsViewModel.settings.plugins.bedlevelvisualizer.timeout().length === 0) self.settingsViewModel.settings.plugins.bedlevelvisualizer.timeout(1800);
 		};
 
 		self.onSettingsHidden = function() {

--- a/octoprint_bedlevelvisualizer/static/js/knockout-sortable.1.2.0.js
+++ b/octoprint_bedlevelvisualizer/static/js/knockout-sortable.1.2.0.js
@@ -1,0 +1,490 @@
+// knockout-sortable 1.2.0 | (c) 2019 Ryan Niemeyer |  http://www.opensource.org/licenses/mit-license
+;(function(factory) {
+    if (typeof define === "function" && define.amd) {
+        // AMD anonymous module
+        define(["knockout", "jquery", "jquery-ui/ui/widgets/sortable", "jquery-ui/ui/widgets/draggable", "jquery-ui/ui/widgets/droppable"], factory);
+    } else if (typeof require === "function" && typeof exports === "object" && typeof module === "object") {
+        // CommonJS module
+        var ko = require("knockout"),
+            jQuery = require("jquery");
+        require("jquery-ui/ui/widgets/sortable");
+        require("jquery-ui/ui/widgets/draggable");
+        require("jquery-ui/ui/widgets/droppable");
+        factory(ko, jQuery);
+    } else {
+        // No module loader (plain <script> tag) - put directly in global namespace
+        factory(window.ko, window.jQuery);
+    }
+})(function(ko, $) {
+    var ITEMKEY = "ko_sortItem",
+        INDEXKEY = "ko_sourceIndex",
+        LISTKEY = "ko_sortList",
+        PARENTKEY = "ko_parentList",
+        DRAGKEY = "ko_dragItem",
+        unwrap = ko.utils.unwrapObservable,
+        dataGet = ko.utils.domData.get,
+        dataSet = ko.utils.domData.set,
+        version = $.ui && $.ui.version,
+        //1.8.24 included a fix for how events were triggered in nested sortables. indexOf checks will fail if version starts with that value (0 vs. -1)
+        hasNestedSortableFix = version && version.indexOf("1.6.") && version.indexOf("1.7.") && (version.indexOf("1.8.") || version === "1.8.24");
+
+    //internal afterRender that adds meta-data to children
+    var addMetaDataAfterRender = function(elements, data) {
+        ko.utils.arrayForEach(elements, function(element) {
+            if (element.nodeType === 1) {
+                dataSet(element, ITEMKEY, data);
+                dataSet(element, PARENTKEY, dataGet(element.parentNode, LISTKEY));
+            }
+        });
+    };
+
+    //prepare the proper options for the template binding
+    var prepareTemplateOptions = function(valueAccessor, dataName) {
+        var result = {},
+            options = {},
+            actualAfterRender;
+
+        //build our options to pass to the template engine
+        if (ko.utils.peekObservable(valueAccessor()).data) {
+            options = unwrap(valueAccessor() || {});
+            result[dataName] = options.data;
+            if (options.hasOwnProperty("template")) {
+                result.name = options.template;
+            }
+        } else {
+            result[dataName] = valueAccessor();
+        }
+
+        ko.utils.arrayForEach(["afterAdd", "afterRender", "as", "beforeRemove", "includeDestroyed", "templateEngine", "templateOptions", "nodes"], function (option) {
+            if (options.hasOwnProperty(option)) {
+                result[option] = options[option];
+            } else if (ko.bindingHandlers.sortable.hasOwnProperty(option)) {
+                result[option] = ko.bindingHandlers.sortable[option];
+            }
+        });
+
+        //use an afterRender function to add meta-data
+        if (dataName === "foreach") {
+            if (result.afterRender) {
+                //wrap the existing function, if it was passed
+                actualAfterRender = result.afterRender;
+                result.afterRender = function(element, data) {
+                    addMetaDataAfterRender.call(data, element, data);
+                    actualAfterRender.call(data, element, data);
+                };
+            } else {
+                result.afterRender = addMetaDataAfterRender;
+            }
+        }
+
+        //return options to pass to the template binding
+        return result;
+    };
+
+    var updateIndexFromDestroyedItems = function(index, items) {
+        var unwrapped = unwrap(items);
+
+        if (unwrapped) {
+            for (var i = 0; i <= index; i++) {
+                //add one for every destroyed item we find before the targetIndex in the target array
+                if (unwrapped[i] && unwrap(unwrapped[i]._destroy)) {
+                    index++;
+                }
+            }
+        }
+
+        return index;
+    };
+
+    //remove problematic leading/trailing whitespace from templates
+    var stripTemplateWhitespace = function(element, name) {
+        var templateSource,
+            templateElement;
+
+        //process named templates
+        if (name) {
+            templateElement = document.getElementById(name);
+            if (templateElement) {
+                templateSource = new ko.templateSources.domElement(templateElement);
+                templateSource.text($.trim(templateSource.text()));
+            }
+        }
+        else {
+            //remove leading/trailing non-elements from anonymous templates
+            $(element).contents().each(function() {
+                if (this && this.nodeType !== 1) {
+                    element.removeChild(this);
+                }
+            });
+        }
+    };
+
+    //connect items with observableArrays
+    ko.bindingHandlers.sortable = {
+        init: function(element, valueAccessor, allBindingsAccessor, data, context) {
+            var $element = $(element),
+                value = unwrap(valueAccessor()) || {},
+                templateOptions = prepareTemplateOptions(valueAccessor, "foreach"),
+                sortable = {},
+                startActual, updateActual;
+
+            stripTemplateWhitespace(element, templateOptions.name);
+
+            //build a new object that has the global options with overrides from the binding
+            $.extend(true, sortable, ko.bindingHandlers.sortable);
+            if (value.options && sortable.options) {
+                ko.utils.extend(sortable.options, value.options);
+                delete value.options;
+            }
+            ko.utils.extend(sortable, value);
+
+            //if allowDrop is an observable or a function, then execute it in a computed observable
+            if (sortable.connectClass && (ko.isObservable(sortable.allowDrop) || typeof sortable.allowDrop == "function")) {
+                ko.computed({
+                    read: function() {
+                        var value = unwrap(sortable.allowDrop),
+                            shouldAdd = typeof value == "function" ? value.call(this, templateOptions.foreach) : value;
+                        ko.utils.toggleDomNodeCssClass(element, sortable.connectClass, shouldAdd);
+                    },
+                    disposeWhenNodeIsRemoved: element
+                }, this);
+            } else {
+                ko.utils.toggleDomNodeCssClass(element, sortable.connectClass, sortable.allowDrop);
+            }
+
+            //wrap the template binding
+            ko.bindingHandlers.template.init(element, function() { return templateOptions; }, allBindingsAccessor, data, context);
+
+            //keep a reference to start/update functions that might have been passed in
+            startActual = sortable.options.start;
+            updateActual = sortable.options.update;
+
+            //ensure draggable table row cells maintain their width while dragging (unless a helper is provided)
+            if ( !sortable.options.helper ) {
+                sortable.options.helper = function(e, ui) {
+                    if (ui.is("tr")) {
+                        ui.children().each(function() {
+                            $(this).width($(this).width());
+                        });
+                    }
+                    return ui;
+                };
+            }
+
+            //initialize sortable binding after template binding has rendered in update function
+            var createTimeout = setTimeout(function() {
+                var dragItem;
+                var originalReceive = sortable.options.receive;
+
+                $element.sortable(ko.utils.extend(sortable.options, {
+                    start: function(event, ui) {
+                        //track original index
+                        var el = ui.item[0];
+                        dataSet(el, INDEXKEY, ko.utils.arrayIndexOf(ui.item.parent().children(), el));
+
+                        //make sure that fields have a chance to update model
+                        ui.item.find("input:focus").change();
+                        if (startActual) {
+                            startActual.apply(this, arguments);
+                        }
+                    },
+                    receive: function(event, ui) {
+                        //optionally apply an existing receive handler
+                        if (typeof originalReceive === "function") {
+                            originalReceive.call(this, event, ui);
+                        }
+
+                        dragItem = dataGet(ui.item[0], DRAGKEY);
+                        if (dragItem) {
+                            //copy the model item, if a clone option is provided
+                            if (dragItem.clone) {
+                                dragItem = dragItem.clone();
+                            }
+
+                            //configure a handler to potentially manipulate item before drop
+                            if (sortable.dragged) {
+                                dragItem = sortable.dragged.call(this, dragItem, event, ui) || dragItem;
+                            }
+                        }
+                    },
+                    update: function(event, ui) {
+                        var sourceParent, targetParent, sourceIndex, targetIndex, arg,
+                            el = ui.item[0],
+                            parentEl = ui.item.parent()[0],
+                            item = dataGet(el, ITEMKEY) || dragItem;
+
+                        if (!item) {
+                            $(el).remove();
+                        }
+                        dragItem = null;
+
+                        //make sure that moves only run once, as update fires on multiple containers
+                        if (item && (this === parentEl) || (!hasNestedSortableFix && $.contains(this, parentEl))) {
+                            //identify parents
+                            sourceParent = dataGet(el, PARENTKEY);
+                            sourceIndex = dataGet(el, INDEXKEY);
+                            targetParent = dataGet(el.parentNode, LISTKEY);
+                            targetIndex = ko.utils.arrayIndexOf(ui.item.parent().children(), el);
+
+                            //take destroyed items into consideration
+                            if (!templateOptions.includeDestroyed) {
+                                sourceIndex = updateIndexFromDestroyedItems(sourceIndex, sourceParent);
+                                targetIndex = updateIndexFromDestroyedItems(targetIndex, targetParent);
+                            }
+
+                            //build up args for the callbacks
+                            if (sortable.beforeMove || sortable.afterMove) {
+                                arg = {
+                                    item: item,
+                                    sourceParent: sourceParent,
+                                    sourceParentNode: sourceParent && ui.sender || el.parentNode,
+                                    sourceIndex: sourceIndex,
+                                    targetParent: targetParent,
+                                    targetIndex: targetIndex,
+                                    cancelDrop: false
+                                };
+
+                                //execute the configured callback prior to actually moving items
+                                if (sortable.beforeMove) {
+                                    sortable.beforeMove.call(this, arg, event, ui);
+                                }
+                            }
+
+                            //call cancel on the correct list, so KO can take care of DOM manipulation
+                            if (sourceParent) {
+                                $(sourceParent === targetParent ? this : ui.sender || this).sortable("cancel");
+                            }
+                            //for a draggable item just remove the element
+                            else {
+                                $(el).remove();
+                            }
+
+                            //if beforeMove told us to cancel, then we are done
+                            if (arg && arg.cancelDrop) {
+                                return;
+                            }
+
+                            //if the strategy option is unset or false, employ the order strategy involving removal and insertion of items
+                            if (!sortable.hasOwnProperty("strategyMove") || sortable.strategyMove === false) {
+                                //do the actual move
+                                if (targetIndex >= 0) {
+                                    if (sourceParent) {
+                                        sourceParent.splice(sourceIndex, 1);
+
+                                        //if using deferred updates plugin, force updates
+                                        if (ko.processAllDeferredBindingUpdates) {
+                                            ko.processAllDeferredBindingUpdates();
+                                        }
+
+                                        //if using deferred updates on knockout 3.4, force updates
+                                        if (ko.options && ko.options.deferUpdates) {
+                                            ko.tasks.runEarly();
+                                        }
+                                    }
+
+                                    targetParent.splice(targetIndex, 0, item);
+                                }
+
+                                //rendering is handled by manipulating the observableArray; ignore dropped element
+                                dataSet(el, ITEMKEY, null);
+                            }
+                            else { //employ the strategy of moving items
+                                if (targetIndex >= 0) {
+                                    if (sourceParent) {
+                                        if (sourceParent !== targetParent) {
+                                            // moving from one list to another
+
+                                            sourceParent.splice(sourceIndex, 1);
+                                            targetParent.splice(targetIndex, 0, item);
+
+                                            //rendering is handled by manipulating the observableArray; ignore dropped element
+                                            dataSet(el, ITEMKEY, null);
+                                            ui.item.remove();
+                                        }
+                                        else {
+                                            // moving within same list
+                                            var underlyingList = unwrap(sourceParent);
+
+                                            // notify 'beforeChange' subscribers
+                                            if (sourceParent.valueWillMutate) {
+                                                sourceParent.valueWillMutate();
+                                            }
+
+                                            // move from source index ...
+                                            underlyingList.splice(sourceIndex, 1);
+                                            // ... to target index
+                                            underlyingList.splice(targetIndex, 0, item);
+
+                                            // notify subscribers
+                                            if (sourceParent.valueHasMutated) {
+                                                sourceParent.valueHasMutated();
+                                            }
+                                        }
+                                    }
+                                    else {
+                                        // drop new element from outside
+                                        targetParent.splice(targetIndex, 0, item);
+
+                                        //rendering is handled by manipulating the observableArray; ignore dropped element
+                                        dataSet(el, ITEMKEY, null);
+                                        ui.item.remove();
+                                    }
+                                }
+                            }
+
+                            //if using deferred updates plugin, force updates
+                            if (ko.processAllDeferredBindingUpdates) {
+                                ko.processAllDeferredBindingUpdates();
+                            }
+
+                            //allow binding to accept a function to execute after moving the item
+                            if (sortable.afterMove) {
+                                sortable.afterMove.call(this, arg, event, ui);
+                            }
+                        }
+
+                        if (updateActual) {
+                            updateActual.apply(this, arguments);
+                        }
+                    },
+                    connectWith: sortable.connectClass ? "." + sortable.connectClass : false
+                }));
+
+                //handle enabling/disabling sorting
+                if (sortable.isEnabled !== undefined) {
+                    ko.computed({
+                        read: function() {
+                            $element.sortable(unwrap(sortable.isEnabled) ? "enable" : "disable");
+                        },
+                        disposeWhenNodeIsRemoved: element
+                    });
+                }
+            }, 0);
+
+            //handle disposal
+            ko.utils.domNodeDisposal.addDisposeCallback(element, function() {
+                //only call destroy if sortable has been created
+                if ($element.data("ui-sortable") || $element.data("sortable")) {
+                    $element.sortable("destroy");
+                }
+
+                ko.utils.toggleDomNodeCssClass(element, sortable.connectClass, false);
+
+                //do not create the sortable if the element has been removed from DOM
+                clearTimeout(createTimeout);
+            });
+
+            return { 'controlsDescendantBindings': true };
+        },
+        update: function(element, valueAccessor, allBindingsAccessor, data, context) {
+            var templateOptions = prepareTemplateOptions(valueAccessor, "foreach");
+
+            //attach meta-data
+            dataSet(element, LISTKEY, templateOptions.foreach);
+
+            //call template binding's update with correct options
+            ko.bindingHandlers.template.update(element, function() { return templateOptions; }, allBindingsAccessor, data, context);
+        },
+        connectClass: 'ko_container',
+        allowDrop: true,
+        afterMove: null,
+        beforeMove: null,
+        options: {}
+    };
+
+    //create a draggable that is appropriate for dropping into a sortable
+    ko.bindingHandlers.draggable = {
+        init: function(element, valueAccessor, allBindingsAccessor, data, context) {
+            var value = unwrap(valueAccessor()) || {},
+                options = value.options || {},
+                draggableOptions = ko.utils.extend({}, ko.bindingHandlers.draggable.options),
+                templateOptions = prepareTemplateOptions(valueAccessor, "data"),
+                connectClass = value.connectClass || ko.bindingHandlers.draggable.connectClass,
+                isEnabled = value.isEnabled !== undefined ? value.isEnabled : ko.bindingHandlers.draggable.isEnabled;
+
+            value = "data" in value ? value.data : value;
+
+            //set meta-data
+            dataSet(element, DRAGKEY, value);
+
+            //override global options with override options passed in
+            ko.utils.extend(draggableOptions, options);
+
+            //setup connection to a sortable
+            draggableOptions.connectToSortable = connectClass ? "." + connectClass : false;
+
+            //initialize draggable
+            $(element).draggable(draggableOptions);
+
+            //handle enabling/disabling sorting
+            if (isEnabled !== undefined) {
+                ko.computed({
+                    read: function() {
+                        $(element).draggable(unwrap(isEnabled) ? "enable" : "disable");
+                    },
+                    disposeWhenNodeIsRemoved: element
+                });
+            }
+
+            //handle disposal
+            ko.utils.domNodeDisposal.addDisposeCallback(element, function() {
+                $(element).draggable("destroy");
+            });
+
+            return ko.bindingHandlers.template.init(element, function() { return templateOptions; }, allBindingsAccessor, data, context);
+        },
+        update: function(element, valueAccessor, allBindingsAccessor, data, context) {
+            var templateOptions = prepareTemplateOptions(valueAccessor, "data");
+
+            return ko.bindingHandlers.template.update(element, function() { return templateOptions; }, allBindingsAccessor, data, context);
+        },
+        connectClass: ko.bindingHandlers.sortable.connectClass,
+        options: {
+            helper: "clone"
+        }
+    };
+
+    // Simple Droppable Implementation
+    // binding that updates (function or observable)
+    ko.bindingHandlers.droppable = {
+        init: function(element, valueAccessor, allBindingsAccessor, data, context) {
+            var value = unwrap(valueAccessor()) || {},
+                options = value.options || {},
+                droppableOptions = ko.utils.extend({}, ko.bindingHandlers.droppable.options),
+                isEnabled = value.isEnabled !== undefined ? value.isEnabled : ko.bindingHandlers.droppable.isEnabled;
+
+            //override global options with override options passed in
+            ko.utils.extend(droppableOptions, options);
+
+            //get reference to drop method
+            value = "data" in value ? value.data : valueAccessor();
+
+            //set drop method
+            droppableOptions.drop = function(event, ui) {
+                var droppedItem = dataGet(ui.draggable[0], DRAGKEY) || dataGet(ui.draggable[0], ITEMKEY);
+                value(droppedItem);
+            };
+
+            //initialize droppable
+            $(element).droppable(droppableOptions);
+
+            //handle enabling/disabling droppable
+            if (isEnabled !== undefined) {
+                ko.computed({
+                    read: function() {
+                        $(element).droppable(unwrap(isEnabled) ? "enable": "disable");
+                    },
+                    disposeWhenNodeIsRemoved: element
+                });
+            }
+
+            //handle disposal
+            ko.utils.domNodeDisposal.addDisposeCallback(element, function() {
+                $(element).droppable("destroy");
+            });
+        },
+        options: {
+            accept: "*"
+        }
+    };
+});

--- a/octoprint_bedlevelvisualizer/templates/bedlevelvisualizer_settings.jinja2
+++ b/octoprint_bedlevelvisualizer/templates/bedlevelvisualizer_settings.jinja2
@@ -137,7 +137,7 @@
 				</div>
 				<div style="padding-top: 5px;" class="row-fluid">
 					<div class="control-group span4">
-						<i class="icon icon-info-sign" title="Revers the adjustment scres turning direction logig" data-toggle="tooltip"></i> Reverse turn direction <input class="input-checkbox" type="checkbox" data-bind="checked: $root.reverse" style="display: inline-block;margin-bottom: 5px;"></input>
+						<i class="icon icon-info-sign" title="Reverse the adjustment screws turning direction logic" data-toggle="tooltip"></i> Reverse turn direction <input class="input-checkbox" type="checkbox" data-bind="checked: $root.reverse" style="display: inline-block;margin-bottom: 5px;"></input>
 					</div>
 					<div class="control-group span3" title="Adjustment screw details." data-toggle="tooltip">
 						<div class="input-append">

--- a/octoprint_bedlevelvisualizer/templates/bedlevelvisualizer_tab.jinja2
+++ b/octoprint_bedlevelvisualizer/templates/bedlevelvisualizer_tab.jinja2
@@ -68,8 +68,7 @@
 		<!-- ko foreach:  { data: $root.mesh_data_y(), noChildContext: true }-->
 			<tr>
 				<td class="text-center info x-axis-label" data-bind="text: $root.mesh_data_y()[$root.descending_y()?$root.mesh_data_y().length-1-$index():$index()]"></td>
-				<!-- ko foreach:  { data: $parent.mesh[$root.descending_y()?$root.mesh_data_y().length-1-$index():$index()], as: 'Zvalue', noChildContext: true }-->
-				<!-- {# angle math #} -->
+				<!-- ko foreach:  { data: $parent.mesh[$root.descending_y()?$root.mesh_data_y().length-1-$index():$index()], as: 'Zvalue', noChildContext: false }-->
 					<td class="text-center" style="padding-left: 0.5em;"
 						data-bind="
 							text: (!$parentContext.$parent.len?
@@ -142,7 +141,6 @@
 							</div>
 						</div>
 					</td>
-					<!-- /ko -->
 					<!-- /ko -->
 				<!-- /ko -->
 			</tr>

--- a/octoprint_bedlevelvisualizer/templates/bedlevelvisualizer_tab.jinja2
+++ b/octoprint_bedlevelvisualizer/templates/bedlevelvisualizer_tab.jinja2
@@ -173,9 +173,9 @@
 					<!-- /ko -->
 					<!-- ko ifnot: $data.len -->
 						<span>Turn direction - </span>
-						<span data-bind="css: {'raise': !$root.reverse(), 'lower': $root.reverse()}, text: $root.reverse()?'anticlockwise (left)':'clockwise (right)'"></span>
+						<span data-bind="css: {'raise': !$root.reverse(), 'lower': $root.reverse()}">clockwise (right)</span>
 						<span> / </span>
-						<span data-bind="css: {'raise': $root.reverse(), 'lower': !$root.reverse()}, text: !$root.reverse()?'anticlockwise (left)':'clockwise (right)'"></span>
+						<span data-bind="css: {'raise': $root.reverse(), 'lower': !$root.reverse()}">anticlockwise (left)</span>
 					<!-- /ko -->
 				</div>
 			</td>

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_bedlevelvisualizer"
 plugin_name = "Bed Visualizer"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "1.0.0rc2"
+plugin_version = "1.0.0rc3"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_bedlevelvisualizer"
 plugin_name = "Bed Visualizer"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "1.0.0rc4"
+plugin_version = "1.0.0rc5"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_bedlevelvisualizer"
 plugin_name = "Bed Visualizer"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "1.0.0rc5"
+plugin_version = "1.0.0"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_bedlevelvisualizer"
 plugin_name = "Bed Visualizer"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.1.15"
+plugin_version = "1.0.0rc1"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_bedlevelvisualizer"
 plugin_name = "Bed Visualizer"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "1.0.0rc3"
+plugin_version = "1.0.0rc4"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_bedlevelvisualizer"
 plugin_name = "Bed Visualizer"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "1.0.0rc1"
+plugin_version = "1.0.0rc2"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
**Added**
* release channels for OctoPrint 1.5.0+ for future rc testing, similar to OctoPrint as described [here](https://community.octoprint.org/t/how-to-use-the-release-channels-to-help-test-release-candidates/402)

**Updated**
* think it's time to go to major version 1.0.0 now with over 19K known installs
* knockout sortable library for OctoPrint 1.5.0 compatibility

**Fixed**
* knockout binding issue due to knockout version update to 3.5.1 in OctoPrint 1.5.0
* issue relative to using center origins and odd numbered mesh grid
* issue with misinterpretation of bed level correction matrix
* typos in reverse direction hover text
* turn direction label coloring