### PR TITLE
Infer mesh values twice on UBL leveling

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,6 +11,8 @@ jobs:
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue has been automatically marked as stale because it has not had activity in 14 days. It will be closed if no further activity occurs in 7 days'
+        days-before-stale: 14
+        days-before-close: 7
         stale-issue-label: 'stale'
         days-before-issue-stale: 14
         days-before-pr-stale: -1

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,19 @@
+name: Mark Stale Issues
+on:
+  workflow_dispatch:
+  schedule:
+  - cron: "0 0 * * *"
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue has been automatically marked as stale because it has not had activity in 14 days. It will be closed if no further activity occurs in 7 days'
+        stale-issue-label: 'stale'
+        days-before-issue-stale: 14
+        days-before-pr-stale: -1
+        days-before-issue-close: 7
+        days-before-pr-close: -1
+        exempt-issue-labels: 'bug,enhancement'

--- a/wiki/gcode-examples.md
+++ b/wiki/gcode-examples.md
@@ -23,6 +23,7 @@ M155 S30  ; reduce temperature reporting rate to reduce output pollution
 M190 S65  ; (optional) wait for the bed to get up to temperature
 G29 P1    ; automatically populate mesh with all reachable points
 G29 P3    ; infer the rest of the mesh values
+G29 P3    ; infer the rest of the mesh values again
 @BEDLEVELVISUALIZER	; tell the plugin to watch for reported mesh
 M420 S1 V ; enabled leveling and report the new mesh
 M500      ; save the new mesh to EEPROM


### PR DESCRIPTION
Some firmwares require the G29 P3 command to be run twice to properly fill out data.