### PR TITLE
Circle mask patch

### DIFF
--- a/octoprint_bedlevelvisualizer/__init__.py
+++ b/octoprint_bedlevelvisualizer/__init__.py
@@ -399,7 +399,7 @@ class bedlevelvisualizer(
             if bed_type == "circular":
                 n = len(self.mesh[0])
                 m = len(self.mesh)
-                circle_mask = self.create_circular_mask(n, m)
+                circle_mask = self.create_circular_mask(m, n)
                 self.mesh = np.array(self.mesh)
                 self.mesh[~circle_mask] = None
                 self.mesh = self.mesh.tolist()


### PR DESCRIPTION
Hello!
I also had a timeout error with a large number of points.
I created a test environment for debugging and found that circle_mask and mesh shapes were not the same.
https://github.com/jneilliii/OctoPrint-BedLevelVisualizer/blob/c50442cd3a741360ef317202cd10c0a7033532f3/octoprint_bedlevelvisualizer/__init__.py#L404

I transposed the mask matrix and it solved the problem.
Is it possible that the create_circular_mask function should be called with m, n parameters instead of n, m?