### PR TITLE
Fix width of settings UI

### DIFF
--- a/octoprint_bedlevelvisualizer/templates/bedlevelvisualizer_settings.jinja2
+++ b/octoprint_bedlevelvisualizer/templates/bedlevelvisualizer_settings.jinja2
@@ -1,4 +1,4 @@
-<div class="container span12">
+<div class="row-fluid">
 	<div class="tabbable">
 		<h4>Bed Visualizer Settings <small>Version {{ plugin_bedlevelvisualizer_plugin_version }}</small></h4>
 		<ul class="nav nav-tabs" id="bedlevelvisualizer_tabs">


### PR DESCRIPTION
At least in UI Customizer with the Flatly theme. Not sure what this was doing outside UIC, but it was kinda broken:
![image](https://user-images.githubusercontent.com/31997505/120372371-06be6980-c30f-11eb-8b27-b38a876144f7.png)

The `span12`/`container` is not really needed, and in with responsive bootstrap it was being set to 1170px.

Fixed with this commit, thought I'm not convinced there isn't a prettier fix. Or maybe, the element can be removed entirely.

Result:
![image](https://user-images.githubusercontent.com/31997505/120372654-5c931180-c30f-11eb-862f-59406a72d5b4.png)
