### PR TITLE
Update tooltip to specify real numbers can be entered

### DIFF
--- a/octoprint_bedlevelvisualizer/templates/bedlevelvisualizer_settings.jinja2
+++ b/octoprint_bedlevelvisualizer/templates/bedlevelvisualizer_settings.jinja2
@@ -88,13 +88,13 @@
 					<div class="control-group span3">
 						<label for="bedlevelvisualizer_z_offset">Z Limits</label>
 						<div class="controls">
-							<input type="text" id="bedlevelvisualizer_z_offset" title="Comma separated list of integers for controlling the z cutoff of the visualized graph in the format of <z-min>,<z-max>. For example the default value is -2,2. This also affects the color map. " data-toggle="tooltip" class="input-small" data-bind="value: settingsViewModel.settings.plugins.bedlevelvisualizer.graph_z_limits">
+							<input type="text" id="bedlevelvisualizer_z_offset" title="Comma separated list of integers or real numbers for controlling the z cutoff of the visualized graph in the format of <z-min>,<z-max>. For example the default value is -2,2. This also affects the color map. " data-toggle="tooltip" class="input-small" data-bind="value: settingsViewModel.settings.plugins.bedlevelvisualizer.graph_z_limits">
 						</div>
 					</div>
 					<div class="control-group span3">
 						<label for="bedlevelvisualizer_camera_position">Camera Position</label>
 						<div class="controls">
-							<input type="text" id="bedlevelvisualizer_camera_position" title="Comma separated list of integers for controlling the position of the camera in the format of <x>,<y>,<z>. For example the default value is -1.25,-1.25,0.25." data-toggle="tooltip" class="input-small" data-bind="value: settingsViewModel.settings.plugins.bedlevelvisualizer.camera_position">
+							<input type="text" id="bedlevelvisualizer_camera_position" title="Comma separated list of integers or real numbers for controlling the position of the camera in the format of <x>,<y>,<z>. For example the default value is -1.25,-1.25,0.25." data-toggle="tooltip" class="input-small" data-bind="value: settingsViewModel.settings.plugins.bedlevelvisualizer.camera_position">
 						</div>
 					</div>
 					<div class="control-group span3">

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -33,7 +33,7 @@ On this tab you will find all the settings related to the graphical aspects of t
 
 ![screenshot](settings_tab_visualization.png)
 
-* **Graph Z Limits:** Comma separated list of integers for controlling the z offset of the visualized graph in the format of <z-min>,<z-max>. For example the default value is -2,2. This also affects the color map.
+* **Graph Z Limits:** Comma separated list of integers or real numbers for controlling the z offset of the visualized graph in the format of <z-min>,<z-max>. For example the default value is -2,2. This also affects the color map.
 * **Camera Positions:** For a couple of examples of different camera positions and how they look, please see [here](camera-positions.md)
 * **Colorscale:** Array of percentage/color pairs, ie <code>[[0, "blue"],[1, "red"]]</code> will create a gradient between blue to red. Percentage values are in decimal format and colors can be HTML hex values or color names surrounded by double quotes. You can also use a named color scale from <a href="https://plotly.com/javascript/colorscales/">here</a>. Clear this setting to load the default option and click Save below.
 * **Enable Local Snapshots of Rendered Graphs:** When enabled every time the graph is rendered a png snapshot will be downloaded by the browser.


### PR DESCRIPTION
I went to set Z Limits as -.5,.5 it didn't work (would be nice if it updated without a new update mesh), I read the comment that it was only integers, but later found out it can accept real numbers.  The camera tooltip also says integers where in that case even the default is a real number.