### PR TITLE
Add in note to flip Y-axis for MK3S machines

### DIFF
--- a/wiki/gcode-examples.md
+++ b/wiki/gcode-examples.md
@@ -56,6 +56,7 @@ G80			; run mesh bed leveling routine.
 @BEDLEVELVISUALIZER	; instruct plugin to start recording responses from printer.
 G81			; report mesh bed leveling status.
 ```
+Note the i3 MK3S requires the Y-axis to be flipped.
 
 ### Prusa Mini
 


### PR DESCRIPTION
I burnt an afternoon trying to figure out why my machine kept on getting worse when entering in values I derived from the bed leveling plugin. Hopefully in the future someone else will save their afternoon by finding this note.